### PR TITLE
Mas i001 nativebackend

### DIFF
--- a/include/aae.hrl
+++ b/include/aae.hrl
@@ -1,1 +1,6 @@
 -define(TREE_SIZE, large).
+-define(MAGIC, 53).
+-define(HEAD_TAG, h). 
+    % Used in leveled as a Tag for head-only objectsm, used in parallel store
+-define(RIAK_TAG, o_rkv).
+    % Tag to be used for finding Riakobjects in native store

--- a/rebar.config
+++ b/rebar.config
@@ -10,5 +10,5 @@
  ]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i115-simplettcache"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "master"}}}
         ]}.

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -459,7 +459,6 @@ compare_branches(BlueBranches, PinkBranches) ->
 %% Find the differences between the lists - and return Bucket/Key pairs
 %% TODO: allow for proper clock comparison e.g. which is more up to date
 compare_clocks(BlueList0, PinkList0) ->
-    io:format("BlueList ~w PinkList ~w~n", [BlueList0, PinkList0]),
     BlueList = lists:usort(BlueList0),
     PinkList = lists:usort(PinkList0),
     MapToKeyFun =  fun({B, K, _V}) -> {B, K} end,

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -459,6 +459,7 @@ compare_branches(BlueBranches, PinkBranches) ->
 %% Find the differences between the lists - and return Bucket/Key pairs
 %% TODO: allow for proper clock comparison e.g. which is more up to date
 compare_clocks(BlueList0, PinkList0) ->
+    io:format("BlueList ~w PinkList ~w~n", [BlueList0, PinkList0]),
     BlueList = lists:usort(BlueList0),
     PinkList = lists:usort(PinkList0),
     MapToKeyFun =  fun({B, K, _V}) -> {B, K} end,

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -543,6 +543,12 @@ do_fetchclock(leveled_ko, Store, Bucket, Key) ->
             value_clock(V)
     end.
 
+-spec do_fetchclock(leveled_so,pid(), binary(), binary(), integer())
+                                            -> aae_controller:version_vector().
+%% @doc
+%% Specific function to allow fetch_clock from leveled segment_ordered backend.
+%% This function is split-out from do_fetchclock/4 to make unit testing of this
+%% scenario easier.
 do_fetchclock(leveled_so, Store, Bucket, Key, Seg) ->
     FoldObjFun  = 
         fun(B, K, V, Acc) ->

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -302,7 +302,12 @@ parallel(startup_metadata, _From, State) ->
 native({fold, Limiter, FoldObjectsFun, InitAcc}, _From, State) ->
     Result = do_fold(State#state.store_type, State#state.store,
                         Limiter, FoldObjectsFun, InitAcc),
-    {reply, Result, native, State}.
+    {reply, Result, native, State};
+native(startup_metadata, _From, State) ->
+    {reply, 
+        {State#state.last_rebuild, none, false}, 
+        parallel, 
+        State#state{shutdown_guid = none}}.
 
 
 loading({mput, ObjectSpecs}, State) ->

--- a/src/aae_util.erl
+++ b/src/aae_util.erl
@@ -165,7 +165,7 @@ test_key_generator(hash) ->
 test_key_generator(v1) ->
     ValueFun = 
         fun() -> 
-            Clock = {leveled_rand:uniform(1000), leveled_rand:uniform(1000)},
+            Clock = [{leveled_rand:uniform(1000), leveled_rand:uniform(1000)}],
             BClock = term_to_binary(Clock),
             Size = leveled_rand:uniform(100000),
             SibCount = leveled_rand:uniform(3),

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -11,6 +11,7 @@ all() -> [dual_store_compare_medium_so,
             dual_store_compare_large_so,
             dual_store_compare_large_ko].
 
+
 -define(ROOT_PATH, "test/").
 
 dual_store_compare_medium_so(_Config) ->
@@ -24,8 +25,6 @@ dual_store_compare_large_so(_Config) ->
 
 dual_store_compare_large_ko(_Config) ->
     dual_store_compare_tester(100000, leveled_ko).
-
-
 
 
 dual_store_compare_tester(InitialKeyCount, StoreType) ->
@@ -218,7 +217,6 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     ok = aae_controller:aae_close(Cntrl1, none),
     ok = aae_controller:aae_close(Cntrl2, none),
     RootPath = reset_filestructure().
-
 
 
 reset_filestructure() ->

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -54,6 +54,13 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     % preflists will be mapped as follows:
     % {2, 0} <-> {3, 0}
     % {2, 1} <-> {3, 1} & {3, 2}
+    %
+    % Think of these preflists in terms of needless partitions for test 
+    % purposes.  Alhtough this is a comparison between 2 'nodes', it is 
+    % more like a comparison between 2 clusters where n=1, there is 1 
+    % vnode, but data is still partitioned into either 2 or 3 partitions.
+    % Don't rtry and make sense of this in term of a ring - the 
+    % mock_vnode_coverage_fold tests have a more Riak ring-like setup.
 
     RootPath = reset_filestructure(),
     VnodePath1 = filename:join(RootPath, "vnode1/"),
@@ -121,8 +128,6 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     Root2C = start_receiver(),
     true = Root1C == Root2C,
     
-
-
     % Confirm no dependencies when using different matching AAE exchanges
     RepairFun = fun(_KL) -> null end,  
 
@@ -333,9 +338,9 @@ mock_vnode_loadandexchange(_Config) ->
     {ExchangeState3, 2} = start_receiver(),
     true = ExchangeState3 == clock_compare,
 
-    RebuildN = mock_kv_vnode:rebuild(VNN, false),
-    RebuildP = mock_kv_vnode:rebuild(VNP, false),
-    % Discover Next rebuild times - should be in the future as both stores w
+    {RebuildN, null} = mock_kv_vnode:rebuild(VNN, false),
+    {RebuildP, null} = mock_kv_vnode:rebuild(VNP, false),
+    % Discover Next rebuild times - should be in the future as both stores
     % were started empty, and hence without the need to rebuild
     io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildN, RebuildP]),
     true = RebuildN > os:timestamp(),
@@ -350,8 +355,8 @@ mock_vnode_loadandexchange(_Config) ->
     % forward from there.
     {ok, VNNa} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
     {ok, VNPa} = mock_kv_vnode:open(MockPathP, parallel, IndexNs, null),
-    RebuildNa = mock_kv_vnode:rebuild(VNNa, false),
-    RebuildPa = mock_kv_vnode:rebuild(VNPa, false),
+    {RebuildNa, null} = mock_kv_vnode:rebuild(VNNa, false),
+    {RebuildPa, null} = mock_kv_vnode:rebuild(VNPa, false),
     io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildNa, RebuildPa]),
     true = RebuildNa > os:timestamp(),
     true = RebuildPa > os:timestamp(),

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -16,9 +16,13 @@
 
 -export([open/3,
             put/4,
-            push/3,
+            push/6,
+            exchange_message/3,
             rebuild/2,
             close/1]).
+
+-export([riak_extract_metadata/1,
+            new_v1/2]).
 
 -record(r_content, {
                     metadata,
@@ -29,7 +33,7 @@
                     bucket,
                     key,
                     contents :: [#r_content{}],
-                    vclock,
+                    vclock = [],
                     updatemetadata=dict:store(clean, true, dict:new()),
                     updatevalue :: term()}).
 
@@ -40,10 +44,22 @@
 
 -record(state, {root_path :: list(),
                 index_ns :: list(tuple()),
-                vnode_id :: list(),
+                aae_controller :: pid(),
+                vnode_store :: pid(),
+                vnode_id :: binary(),
                 vnode_sqn = 1 :: integer()}).
 
 -include_lib("eunit/include/eunit.hrl").
+
+-define(BUCKET_SDG, <<"MD">>).
+-define(KEY_SDG, <<"SHUDOWN_GUID">>).
+-define(TAG_SDG, o).
+-define(RIAK_TAG, o_rkv).
+-define(REBUILD_SCHEDULE, {1, 60}).
+-define(LASTMOD_LEN, 29). 
+-define(V1_VERS, 1).
+-define(MAGIC, 53).  
+-define(EMPTY_VTAG_BIN, <<"e">>).
 
 
 -type r_object() :: #r_object{}.
@@ -68,11 +84,11 @@ open(Path, AAEType, IndexNs) ->
 put(Vnode, Object, IndexN, OtherVnodes) ->
     gen_server:call(Vnode, {put, Object, IndexN, OtherVnodes}).
 
--spec push(pid(), r_object(), tuple()) -> ok.
+-spec push(pid(), binary(), binary(), list(tuple()), binary(), tuple()) -> ok.
 %% @doc
 %% Push a new object in the store, updating AAE
-push(Vnode, Object, IndexN) ->
-    gen_server:cast(Vnode, {push, Object, IndexN}).
+push(Vnode, Bucket, Key, UpdClock, ObjectBin, IndexN) ->
+    gen_server:cast(Vnode, {push, Bucket, Key, UpdClock, ObjectBin, IndexN}).
 
 -spec rebuild(pid(), boolean()) -> erlang:timestamp().
 %% @doc
@@ -82,9 +98,16 @@ rebuild(Vnode, ForceRebuild) ->
     gen_server:call(Vnode, {rebuild, ForceRebuild}).
 
 
+-spec exchange_message(pid(), tuple()|atom(), list(tuple())) -> ok.
+%% @doc
+%% Handle a message from an AAE exchange
+exchange_message(Vnode, Msg, IndexNs) ->
+    gen_server:call(Vnode, {aae, Msg, IndexNs}).
+
+
 -spec close(pid()) -> ok.
 %% @doc
-%% Cloe the vnode, and any aae controller
+%% Close the vnode, and any aae controller
 close(Vnode) ->
     gen_server:call(Vnode, close).
 
@@ -93,33 +116,150 @@ close(Vnode) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([_Opts]) ->
+init([Opts]) ->
     % Start the vnode backend
     % Get the shutdown GUID
     % Delete the shutdown GUID
     % Check is_empty
     % Start the aae_controller 
     % Report back OK
-    {ok, #state{}}.
+    RP = Opts#options.root_path,
+    {ok, VnSt} = 
+        leveled_bookie:book_start(RP, 4000, 100000000, none),
+    ShutdownGUID = 
+        case leveled_bookie:book_get(VnSt, ?BUCKET_SDG, ?KEY_SDG, ?TAG_SDG) of
+            not_found ->
+                none;
+            {ok, Value} when is_list(Value) ->
+                ok = leveled_bookie:book_delete(VnSt, 
+                                                ?BUCKET_SDG, 
+                                                ?KEY_SDG, 
+                                                []),
+                Value
+        end,
+    IsEmpty = leveled_bookie:book_isempty(VnSt, ?RIAK_TAG),
+    KeyStoreType = 
+        case Opts#options.aae of 
+            native ->
+                {native, leveled_ko, VnSt};
+            parallel ->
+                {parallel, leveled_so}
+        end,
+    {ok, AAECntrl} = 
+        aae_controller:aae_start(KeyStoreType, 
+                                    {IsEmpty, ShutdownGUID}, 
+                                    ?REBUILD_SCHEDULE, 
+                                    Opts#options.index_ns, 
+                                    RP, 
+                                    fun riak_extract_metadata/1),
+    {ok, #state{root_path = RP,
+                vnode_store = VnSt,
+                index_ns = Opts#options.index_ns,
+                aae_controller = AAECntrl,
+                vnode_id = list_to_binary(leveled_codec:generate_uuid())}}.
 
-handle_call({put, _Object, _IndexN, _OtherVnodes}, _From, State) ->
+handle_call({put, Object, IndexN, OtherVnodes}, _From, State) ->
     % Get Bucket and Key from object
     % Do head request
     % Compare clock, update clock
     % Send update to other stores
-    % Reoprt back OK
-    {reply, ok, State};
+    % Update AAE
+    % Report back OK
+    Bucket = Object#r_object.bucket,
+    Key = Object#r_object.key,
+
+    {UpdClock, PrevClock} = 
+        case leveled_bookie:book_head(State#state.vnode_store, 
+                                        Bucket, Key, ?RIAK_TAG) of
+            not_found ->
+                {[{State#state.vnode_id, State#state.vnode_sqn}],
+                    none};
+            {ok, Head} ->
+                {VclockBin, _SMB, _LMs} 
+                    = leveled_codec:riak_metadata_frombinary(Head),
+                Clock0 = 
+                    term_to_binary(VclockBin),
+                Clock1 = 
+                    [{State#state.vnode_id, State#state.vnode_sqn}|Clock0],
+                {lists:ukeysort(Clock1, 1), Clock0}
+        end,
+    ObjectBin = new_v1(UpdClock, Object#r_object.contents),
+    VVEBin = to_aae_binary(ObjectBin),
+    leveled_bookie:book_put(State#state.vnode_store, 
+                                Bucket, 
+                                Key, 
+                                ObjectBin, 
+                                [], 
+                                ?RIAK_TAG),
+    
+    ok = aae_controller:aae_put(State#state.aae_controller, 
+                                IndexN, 
+                                Bucket, Key, 
+                                UpdClock, PrevClock, 
+                                VVEBin),
+    
+    lists:foreach(fun(VN) -> 
+                        push(VN, Bucket, Key, UpdClock, ObjectBin, IndexN)
+                    end, 
+                    OtherVnodes),
+
+    {reply, ok, State#state{vnode_sqn = State#state.vnode_sqn + 1}};
 handle_call({rebuild, _ForceRebuild}, _From, State) ->
     % Check next rebuild
     % Reply with next rebuild TS
     % If force rebuild, then trigger rebuild
     {reply, ok, State};
+handle_call({aae, Msg, IndexNs}, From, State) ->
+    ReturnFun = 
+        fun(Reply) ->
+            gen_server:reply(From, Reply)
+        end,
+    case Msg of 
+        fetch_root ->
+            aae_controller:aae_mergeroot(State#state.aae_controller, 
+                                            IndexNs, 
+                                            ReturnFun);
+        {fetch_branches, BranchIDs} ->
+            aae_controller:aae_mergebranches(State#state.aae_controller, 
+                                                IndexNs, 
+                                                BranchIDs, 
+                                                ReturnFun);
+        {fetch_clocks, SegmentIDs} ->
+            aae_controller:aae_fetchclocks(State#state.aae_controller,
+                                                IndexNs,
+                                                SegmentIDs,
+                                                ReturnFun)
+    end,
+    {reply, ok, State};
 handle_call(close, _From, State) ->
     {stop, normal, ok, State}.
 
-handle_cast({push, _Object, _IndexN}, State) ->
-    % As PUT, but vnode check may form a sibling 
-    {ok, State}.
+handle_cast({push, Bucket, Key, UpdClock, ObjectBin, IndexN}, State) ->
+    % As PUT, but don't increment vclock, replace regardless of current state
+    PrevClock = 
+        case leveled_bookie:book_head(State#state.vnode_store, 
+                                        Bucket, Key, ?RIAK_TAG) of
+            not_found ->
+                none;
+            {ok, Head} ->
+                {VclockBin, _SMB, _LMs} 
+                    = leveled_codec:riak_metadata_frombinary(Head),
+                term_to_binary(VclockBin)
+        end,
+    leveled_bookie:book_put(State#state.vnode_store, 
+                                Bucket, 
+                                Key, 
+                                ObjectBin, 
+                                [], 
+                                ?RIAK_TAG),
+    
+    ok = aae_controller:aae_put(State#state.aae_controller, 
+                                IndexN, 
+                                Bucket, Key, 
+                                UpdClock, PrevClock, 
+                                to_aae_binary(ObjectBin)),
+
+    {noreply, State}.
 
 
 handle_info(_Info, State) ->
@@ -136,14 +276,99 @@ code_change(_OldVsn, State, _Extra) ->
 %%% External functions
 %%%============================================================================
 
+-spec riak_extract_metadata(binary()) 
+                                -> {integer(), integer(), integer(), any()}.
+%% @doc
+%% The vnode should produce a special version of the object binary which with 
+%% this function cna be quickly unpacked.
+%%
+%% If the backend supports can rely on a special PUT that spits back the 
+%% metadata - so this doesn't have to be unpacked spearately by the backend.
+riak_extract_metadata(ObjBin) ->
+    <<ObjSize:32/integer, 
+        SibCount:32/integer,
+        IndexHash:32/integer, 
+        HeadLen:32/integer,
+        Head:HeadLen/binary>> = ObjBin,
+    {ObjSize, SibCount, IndexHash, binary_to_term(Head)}.
 
+
+%% V1 Riak Object Binary Encoding
+%% -type binobj_header()     :: <<53:8, Version:8, VClockLen:32, VClockBin/binary,
+%%                                SibCount:32>>.
+%% -type binobj_flags()      :: <<Deleted:1, 0:7/bitstring>>.
+%% -type binobj_umeta_pair() :: <<KeyLen:32, Key/binary, ValueLen:32, Value/binary>>.
+%% -type binobj_meta()       :: <<LastMod:LastModLen, VTag:128, binobj_flags(),
+%%                                [binobj_umeta_pair()]>>.
+%% -type binobj_value()      :: <<ValueLen:32, ValueBin/binary, MetaLen:32,
+%%                                [binobj_meta()]>>.
+%% -type binobj()            :: <<binobj_header(), [binobj_value()]>>.
+new_v1(Vclock, Siblings) ->
+    VclockBin = term_to_binary(Vclock),
+    VclockLen = byte_size(VclockBin),
+    SibCount = length(Siblings),
+    SibsBin = bin_contents(Siblings),
+    <<?MAGIC:8/integer, ?V1_VERS:8/integer, 
+        VclockLen:32/integer, VclockBin/binary, 
+        SibCount:32/integer, SibsBin/binary>>.
+
+bin_content(#r_content{metadata=Meta0, value=Val}) ->
+    TypeTag = 1,
+    ValBin = encode_maybe_binary(Val, TypeTag),
+    ValLen = byte_size(ValBin),
+    MetaBin = meta_bin(Meta0),
+    MetaLen = byte_size(MetaBin),
+    <<ValLen:32/integer, ValBin:ValLen/binary, 
+        MetaLen:32/integer, MetaBin:MetaLen/binary>>.
+
+encode_maybe_binary(Value, TypeTag) when is_binary(Value) ->
+    <<TypeTag, Value/binary>>.
+
+bin_contents(Contents) ->
+    F = fun(Content, Acc) ->
+                <<Acc/binary, (bin_content(Content))/binary>>
+        end,
+    lists:foldl(F, <<>>, Contents).
+
+meta_bin(MetaData) ->
+    {Mega,Secs,Micro} = os:timestamp(),
+    LastModBin = <<Mega:32/integer, Secs:32/integer, Micro:32/integer>>,
+    Deleted = <<0>>,
+    RestBin = term_to_binary(MetaData),
+    VTagBin = ?EMPTY_VTAG_BIN,
+    VTagLen = byte_size(VTagBin),
+    <<LastModBin/binary, VTagLen:8/integer, VTagBin:VTagLen/binary,
+      Deleted:1/binary-unit:8, RestBin/binary>>.
 
 
 %%%============================================================================
 %%% Internal functions
 %%%============================================================================
 
+to_aae_binary(ObjectBin) ->
+    ObjectSize = byte_size(ObjectBin),
+    <<?MAGIC:8/integer, ?V1_VERS:8/integer, 
+        VclockLen:32/integer, _VclockBin:VclockLen/binary, 
+        SibCount:32/integer, SibsBin/binary>> = ObjectBin,
 
+    IndexHash = erlang:phash2([]), % faking here
+
+    HeadOnly = strip_metabinary(SibCount, SibsBin, <<>>),
+    HeadSize = byte_size(HeadOnly),
+    <<ObjectSize:32/integer, SibCount:32/integer, IndexHash:32/integer, 
+        HeadSize:32/integer, HeadOnly/binary>>.
+
+
+strip_metabinary(0, <<>>, MetaBinAcc) ->
+    MetaBinAcc;
+strip_metabinary(SibCount, SibBin, MetaBinAcc) ->
+    <<ValLen:32/integer, _ValBin:ValLen/binary, 
+        MetaLen:32/integer, MetaBin:MetaLen/binary, Rest/binary>> = SibBin,
+    strip_metabinary(SibCount - 1, 
+                        Rest, 
+                        <<MetaBinAcc/binary, 
+                            MetaLen:32/integer, 
+                            MetaBin:MetaLen/binary>>).
 
 
 %%%============================================================================

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -1,0 +1,157 @@
+%% -------- Overview ---------
+%%
+%% A simplified mock of riak_kv_vnode for testing
+
+
+-module(mock_kv_vnode).
+
+-behaviour(gen_server).
+
+-export([init/1,
+            handle_call/3,
+            handle_cast/2,
+            handle_info/2,
+            terminate/2,
+            code_change/3]).
+
+-export([open/3,
+            put/4,
+            push/3,
+            rebuild/2,
+            close/1]).
+
+-record(r_content, {
+                    metadata,
+                    value :: term()
+                    }).
+
+-record(r_object, {
+                    bucket,
+                    key,
+                    contents :: [#r_content{}],
+                    vclock,
+                    updatemetadata=dict:store(clean, true, dict:new()),
+                    updatevalue :: term()}).
+
+-record(options, {aae :: parallel|native,
+                    index_ns :: list(tuple()),
+                    root_path :: list()}).
+
+
+-record(state, {root_path :: list(),
+                index_ns :: list(tuple()),
+                vnode_id :: list(),
+                vnode_sqn = 1 :: integer()}).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+-type r_object() :: #r_object{}.
+
+%%%============================================================================
+%%% API
+%%%============================================================================
+
+-spec open(list(), atom(), list(tuple())) -> {ok, pid()}.
+%% @doc
+%% Open a mock vnode
+open(Path, AAEType, IndexNs) ->
+    gen_server:start(?MODULE, 
+                        [#options{aae = AAEType, 
+                                    index_ns = IndexNs, 
+                                    root_path = Path}], 
+                        []).
+
+-spec put(pid(), r_object(), tuple(), list(pid())) -> ok.
+%% @doc
+%% Put a new object in the store, updating AAE - and co-ordinating
+put(Vnode, Object, IndexN, OtherVnodes) ->
+    gen_server:call(Vnode, {put, Object, IndexN, OtherVnodes}).
+
+-spec push(pid(), r_object(), tuple()) -> ok.
+%% @doc
+%% Push a new object in the store, updating AAE
+push(Vnode, Object, IndexN) ->
+    gen_server:cast(Vnode, {push, Object, IndexN}).
+
+-spec rebuild(pid(), boolean()) -> erlang:timestamp().
+%% @doc
+%% Prompt for the next rebuild time, using ForceRebuild=true to oevrride that
+%% time
+rebuild(Vnode, ForceRebuild) ->
+    gen_server:call(Vnode, {rebuild, ForceRebuild}).
+
+
+-spec close(pid()) -> ok.
+%% @doc
+%% Cloe the vnode, and any aae controller
+close(Vnode) ->
+    gen_server:call(Vnode, close).
+
+
+%%%============================================================================
+%%% gen_server callbacks
+%%%============================================================================
+
+init([_Opts]) ->
+    % Start the vnode backend
+    % Get the shutdown GUID
+    % Delete the shutdown GUID
+    % Check is_empty
+    % Start the aae_controller 
+    % Report back OK
+    {ok, #state{}}.
+
+handle_call({put, _Object, _IndexN, _OtherVnodes}, _From, State) ->
+    % Get Bucket and Key from object
+    % Do head request
+    % Compare clock, update clock
+    % Send update to other stores
+    % Reoprt back OK
+    {reply, ok, State};
+handle_call({rebuild, _ForceRebuild}, _From, State) ->
+    % Check next rebuild
+    % Reply with next rebuild TS
+    % If force rebuild, then trigger rebuild
+    {reply, ok, State};
+handle_call(close, _From, State) ->
+    {stop, normal, ok, State}.
+
+handle_cast({push, _Object, _IndexN}, State) ->
+    % As PUT, but vnode check may form a sibling 
+    {ok, State}.
+
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%%%============================================================================
+%%% External functions
+%%%============================================================================
+
+
+
+
+%%%============================================================================
+%%% Internal functions
+%%%============================================================================
+
+
+
+
+%%%============================================================================
+%%% Test
+%%%============================================================================
+
+-ifdef(TEST).
+
+-endif.
+
+

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -243,6 +243,7 @@ handle_call({rebuild, true}, _From, State) ->
 
     ok = aae_controller:aae_rebuildtrees(State#state.aae_controller, 
                                             State#state.index_ns,
+                                            State#state.preflist_fun,
                                             Worker),
 
     {reply, {os:timestamp(), null}, State#state{aae_rebuild = null}};


### PR DESCRIPTION
Add native support, as well as rebuild store support:

rebar3 as test do dialyzer, cover --reset, eunit --cover, ct --cover, cover --verbose
===> Verifying dependencies...
===> Compiling kv_index_hashtree
===> Dialyzer starting, this may take a while...
===> Updating plt...
===> Resolving files...
===> Checking 156 files in "/Users/martinsumner/dbroot/kv_index_tictactree/_build/test/rebar3_18.3_plt"...
===> Doing success typing analysis...
===> Resolving files...
===> Analyzing 6 files with "/Users/martinsumner/dbroot/kv_index_tictactree/_build/test/rebar3_18.3_plt"...
===> Verifying dependencies...
===> Resetting collected cover data...
===> Verifying dependencies...
===> Compiling kv_index_hashtree
===> Performing EUnit tests...
................................

Top 10 slowest tests (11.038 seconds, 95.8% of total time):
  aae_keystore:so_big_load_test_/0
    2.790 seconds
  aae_treecache:corrupt_save_test/0
    2.609 seconds
  aae_keystore:ko_big_load_test_/0
    2.233 seconds
  aae_controller:basic_cache_rebuild_ko_test/0
    0.941 seconds
  aae_controller:varyindexn_cache_rebuild_ko_test/0
    0.592 seconds
  aae_controller:varyindexn_cache_rebuild_so_test/0
    0.586 seconds
  aae_controller:rebuild_notempty_test/0
    0.553 seconds
  aae_controller:basic_cache_rebuild_so_test/0
    0.465 seconds
  aae_treecache:simple_test/0
    0.138 seconds
  aae_controller:rebuild_onempty_test/0
    0.131 seconds

Finished in 11.525 seconds
32 tests, 0 failures
===> Verifying dependencies...
===> Compiling kv_index_hashtree
===> Running Common Test suites...
%%% basic_SUITE ==> dual_store_compare_medium_so: OK
%%% basic_SUITE ==> dual_store_compare_medium_ko: OK
%%% basic_SUITE ==> dual_store_compare_large_so: OK
%%% basic_SUITE ==> dual_store_compare_large_ko: OK
%%% basic_SUITE ==> mock_vnode_loadexchangeandrebuild: OK
%%% basic_SUITE ==> mock_vnode_coveragefold_nativemedium: OK
%%% basic_SUITE ==> mock_vnode_coveragefold_nativesmall: OK
%%% basic_SUITE ==> mock_vnode_coveragefold_parallelmedium: OK
All 8 tests passed.
===> Verifying dependencies...
===> Compiling kv_index_hashtree
===> Performing cover analysis...
  |------------------------|------------|
  |                module  |  coverage  |
  |------------------------|------------|
  |              aae_util  |      100%  |
  |         aae_treecache  |      100%  |
  |          aae_exchange  |      100%  |
  |          aae_keystore  |      100%  |
  |        aae_controller  |      100%  |
  |            aae_runner  |      100%  |
  |------------------------|------------|
  |                 total  |      100%  |
  |------------------------|------------|
  coverage calculated from:
    /Users/martinsumner/dbroot/kv_index_tictactree/_build/test/cover/eunit.coverdata
    /Users/martinsumner/dbroot/kv_index_tictactree/_build/test/cover/ct.coverdata
  cover summary written to: /Users/martinsumner/dbroot/kv_index_tictactree/_build/test/cover/index.html