### PR TITLE
RepairFun to take clock comparison

### DIFF
--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -788,8 +788,8 @@ repair_fun(SourceList, Cntrl, NVal) ->
     RepairFun = 
         fun(BucketKeyL) ->
             FoldFun =
-                fun(BucketKeyT, Acc) -> 
-                    {{B0, K0}, V0} = lists:keyfind(BucketKeyT, 1, Lookup),
+                fun({{B0, K0}, _VCDelta}, Acc) -> 
+                    {{B0, K0}, V0} = lists:keyfind({B0, K0}, 1, Lookup),
                     [{B0, K0, V0}|Acc]
                 end,
             KVL = lists:foldl(FoldFun, [], BucketKeyL),


### PR DESCRIPTION
Rather than give the RepairFun just a bunch of keys thta have differences, give th eRepairfun both the BlueClock and the PinkClock for each difference.

For  intra-riak-cluster repair, this may be irrelevant (as the repair should be by read_repair).  Howver, for inter-cluster repair this cna be used ot avoid needlessly sending out of date data between clusters only for it to be rejected on the other side.