### PR TITLE
Mas i14 rehash

### DIFF
--- a/docs/RIAK_3_AAE.md
+++ b/docs/RIAK_3_AAE.md
@@ -16,9 +16,11 @@
 
     - If the change is a delete the CurrentClock should be none.  
 
-    - If the change is a fresh put, the PreviousClock should be none.
+    - If the change is a fresh put, the PreviousClock should be none (this includes any PUt on the write once path).
 
     - If the change is a LWW PUT in an non-index backend, the PreviousClock should be undefined.
+
+    - If the change is a rehash, then the PreviousClock should be undefined.
 
 - The `aae_controller` receives this update as a cast.  It has two tasks now:
 

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -510,8 +510,13 @@ handle_cast({put, IndexN, Bucket, Key, Clock, PrevClock, BinaryObj}, State) ->
     PrevClock0 = 
         case PrevClock of 
             undefined ->
-                % Should never be native
-                resolve_clock(Bucket, Key, State#state.key_store);
+                case State#state.parallel_keystore of 
+                    true ->
+                        resolve_clock(Bucket, Key, State#state.key_store);
+                    false ->
+                        % An inert change will be generated
+                        Clock
+                end;
             _ ->
                 PrevClock
         end,
@@ -1087,6 +1092,7 @@ varyindexn_cache_rebuild_tester(StoreType) ->
 
     ok = aae_close(Cntrl0, "0000"),
     aae_util:clean_subdir(RootPath).
+
 
 coverage_cheat_test() ->
     {noreply, _State0} = handle_info(timeout, #state{}),

--- a/src/aae_runner.erl
+++ b/src/aae_runner.erl
@@ -15,7 +15,7 @@
             code_change/3]).
 
 -export([runner_start/0, 
-            runner_clockfold/3,
+            runner_clockfold/4,
             runner_stop/1]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -38,8 +38,8 @@ runner_start() ->
 
 %% @doc
 %% Pass some work to a runner
-runner_clockfold(Runner, Folder, ReturnFun) ->
-    gen_server:cast(Runner, {work, Folder, ReturnFun}).
+runner_clockfold(Runner, Folder, ReturnFun, SizeFun) ->
+    gen_server:cast(Runner, {work, Folder, ReturnFun, SizeFun}).
 %% @doc
 %% Close the runner
 runner_stop(Runner) ->
@@ -55,11 +55,11 @@ init([]) ->
 handle_call(close, _From, State) ->
     {stop, normal, ok, State}.
 
-handle_cast({work, Folder, ReturnFun}, State) ->
+handle_cast({work, Folder, ReturnFun, SizeFun}, State) ->
     SW = os:timestamp(),
     Results = Folder(),
 
-    RS0 = State#state.result_size + length(Results),
+    RS0 = State#state.result_size + SizeFun(Results),
     QT0 = State#state.query_time + timer:now_diff(os:timestamp(), SW),
     QC0 = State#state.query_count + 1,
     {RS1, QT1, QC1} = maybe_log(RS0, QT0, QC0, ?LOG_FREQUENCY),

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -646,7 +646,8 @@ mock_vnode_coveragefolder(Type, InitialKeyCount) ->
 
     % Fold over a valid coverage plan to find siblings (there are none) 
     SibCountFoldFun =
-        fun(B, K, {SC}, {NoSibAcc, SibAcc}) ->
+        fun(B, K, V, {NoSibAcc, SibAcc}) ->
+            {sibcount, SC} = lists:keyfind(sibcount, 1, V),
             case SC of 
                 1 -> {NoSibAcc + 1, SibAcc};
                 _ -> {NoSibAcc, [{B, K}|SibAcc]}
@@ -683,7 +684,9 @@ mock_vnode_coveragefolder(Type, InitialKeyCount) ->
     % A fold over two coverage plans to compare the list of {B, K, H, Sz} 
     % tuples found within the coverage plans
     HashSizeFoldFun =
-        fun(B, K, {H, Sz}, Acc) ->
+        fun(B, K, V, Acc) ->
+            {hash, H} = lists:keyfind(hash, 1, V),
+            {size, Sz} = lists:keyfind(size, 1, V),
             [{B, K, H, Sz}|Acc]
         end,
 


### PR DESCRIPTION
This changes the approach to rehash.  Individual rehash requests (e.g. requests where the old clock is undefined) are ignore by the native store.  Also the tree can now be rebuilt if it has got out of sync with the store, as each fetch_clocks rebuilds the tree.

Given this, it may make sense to now end the Shutdown GUID behaviour, and periodically save tree caches.  It makes sense to restore an incomplete tree cache if an incomplete tree cache can be rebuilt through tree cache.