### PR TITLE
Mas i21 rebuild2

### DIFF
--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -404,6 +404,7 @@ handle_call({rebuild_trees, IndexNs, PreflistFun, WorkerFun, OnlyIfBroken},
             {reply, skipped, State};
         false ->
             aae_util:log("AAE06", [IndexNs], logs()),
+            SW = os:timestamp(),
             % Before the fold flush all the PUTs (if a parallel store)
             ok = maybe_flush_puts(State#state.key_store, 
                                     State#state.objectspecs_queue,
@@ -440,7 +441,8 @@ handle_call({rebuild_trees, IndexNs, PreflistFun, WorkerFun, OnlyIfBroken},
                 end,
             FinishFun = 
                 fun(FoldTreeCaches) ->
-                    lists:foreach(FinishTreeFun, FoldTreeCaches)
+                    lists:foreach(FinishTreeFun, FoldTreeCaches),
+                    aae_util:log_timer("AAE13", [], SW, logs())
                 end,
 
             WorkerFun(Folder, FinishFun),
@@ -926,7 +928,9 @@ logs() ->
         {"AAE11",
             {info, "Next rebuild scheduled for ~w"}},
         {"AAE12",
-            {info, "Received rebuild store for parallel store ~w"}}
+            {info, "Received rebuild store for parallel store ~w"}},
+        {"AAE13",
+            {info, "Completed tree rebuild"}}
     
     ].
 

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -273,7 +273,8 @@ aae_close(Pid) ->
 %% - the Preflists to be rebuilt (we do not assume that preflists stay 
 %% constant within a controller)
 %% - a Preflist Fun for native stores (to calculate the IndexN as the preflist
-%% is not stored)
+%% is not stored).  PreflistFun should be a 2-arity function on the Bucket and
+%% Key and return the IndexN
 %% - a 2-arity WorkerFun which can be passed a Fold and a FinishFun e.g. 
 %% WorkerFun(Folder, FinishFun), with the FinishFun to be called once the 
 %% Fold is complete (being passed the result of the Folder()).

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -284,12 +284,12 @@ aae_rebuildtrees(Pid, IndexNs, PreflistFun, WorkerFun, OnlyIfBroken) ->
                             OnlyIfBroken}).
 
 
--spec aae_rebuildstore(pid(), fun()) -> {ok, fun()|skip, fun()}.
+-spec aae_rebuildstore(pid(), fun()) -> {ok, fun()|skip, fun()}|ok.
 %% @doc
 %% Prompt the rebuild of the actual AAE key store.  This should return an
 %% object fold fun, and a finish fun.  The object fold fun may be skip if it 
 %% is a native store and so no fold is required.  The finish fun should be 
-%% called once the fold is completed (or imediately if the fold fun is skip).
+%% called once the fold is completed (or immediately if the fold fun is skip).
 %%
 %% The SplitValueFun must be able to take the {B, K, V} to be used in the 
 %% object fold and convert it into {B, K, {IndexN, CurrentClock}} 

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -730,9 +730,7 @@ foldobjects_buildtrees(IndexNs) ->
             {preflist, IndexN} = lists:keyfind(preflist, 1, V),
             {hash, Hash} = lists:keyfind(hash, 1, V),
             BinK = aae_util:make_binarykey(B, K),
-            BinExtractFun = 
-                fun(_BK, _V) -> 
-                    {BinK, {is_hash, Hash}} end,
+            BinExtractFun = fun(_BK, _V) -> {BinK, {is_hash, Hash}} end,
             case lists:keyfind(IndexN, 1, Acc) of 
                 {IndexN, Tree} ->
                     Tree0 = 
@@ -747,6 +745,7 @@ foldobjects_buildtrees(IndexNs) ->
                                                 BinExtractFun),
                     lists:keyreplace(IndexN, 1, Acc, {IndexN, Tree0});
                 false ->
+                    aae_util:log("AAE14", [IndexN], logs()),
                     Acc 
             end
         end,
@@ -893,7 +892,7 @@ hash_clocks(CurrentVV, PrevVV) ->
 hash_clock(none) ->
     0;
 hash_clock(Clock) ->
-    erlang:phash2(Clock).
+    erlang:phash2(lists:sort(Clock)).
 
 %%%============================================================================
 %%% log definitions
@@ -934,7 +933,10 @@ logs() ->
         {"AAE12",
             {info, "Received rebuild store for parallel store ~w"}},
         {"AAE13",
-            {info, "Completed tree rebuild"}}
+            {info, "Completed tree rebuild"}},
+        {"AAE14",
+            {info, "Mismatch finding unexpected IndexN in fold of ~w"}} 
+                % Probably should be switched to debug
     
     ].
 

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -330,7 +330,7 @@ init([Opts]) ->
             {native, StoreType, BackendPid} ->
                 aae_util:log("AAE02", [StoreType], logs()),
                 StoreRP = filename:join([RootPath, StoreType, ?STORE_PATH]),
-                {ok, {LastRebuild, _GUID, _IsE}, KeyStorePid} =
+                {ok, {LastRebuild, _IsE}, KeyStorePid} =
                     aae_keystore:store_nativestart(StoreRP, 
                                                     StoreType, 
                                                     BackendPid),

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -597,12 +597,12 @@ logs() ->
             {info, "Exchange id=~s led to prompting of repair_count=~w"}},
         {"EX005",
             {info, "Exchange id=~s throttled count=~w at state=~w"}},
-        {"EX006", % TODO: should be debug in production
-            {info, "State change to ~w for exchange id=~s"}},
-        {"EX007", % TODO: should be changed to debug in production
-            {info, "Reply received for colour=~w in exchange id=~s"}},
-        {"EX008", % TODO: should be changed to debug in production
-            {info, "Comparison between BlueList ~w and PinkList ~w"}}
+        {"EX006",
+            {debug, "State change to ~w for exchange id=~s"}},
+        {"EX007", 
+            {debug, "Reply received for colour=~w in exchange id=~s"}},
+        {"EX008", 
+            {debug, "Comparison between BlueList ~w and PinkList ~w"}}
         ].
 
 

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -718,8 +718,7 @@ do_fetchclock(leveled_so, Store, Bucket, Key) ->
     Seg0 = generate_treesegment(Seg),
     do_fetchclock(leveled_so, Store, Bucket, Key, Seg0);
 do_fetchclock(leveled_ko, Store, Bucket, Key) ->
-    HeadKey = {Key, ?NULL_SUBKEY},
-    case leveled_bookie:book_head(Store, Bucket, HeadKey, ?HEAD_TAG) of
+    case leveled_bookie:book_headonly(Store, Bucket, Key, ?NULL_SUBKEY) of
         not_found ->
             none;
         {ok, V} ->

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -139,7 +139,7 @@
 %%%============================================================================
 
 -spec store_parallelstart(list(), parallel_stores()) -> 
-                {ok, {os:timestamp()|never, list()|none, boolean()}, pid()}.
+                {ok, {os:timestamp()|never, boolean()}, pid()}.
 %% @doc
 %% Start a store to be run in parallel mode
 store_parallelstart(Path, leveled_so) ->
@@ -158,7 +158,7 @@ store_parallelstart(Path, leveled_ko) ->
     store_startupdata(Pid).
 
 -spec store_nativestart(list(), native_stores(), pid()) ->
-                {ok, {os:timestamp()|never, list()|none, boolean()}, pid()}.
+                {ok, {os:timestamp()|never, boolean()}, pid()}.
 %% @doc
 %% Start a keystore in native mode.  In native mode the store is just a pass
 %% through for queries - and there will be no puts
@@ -347,7 +347,8 @@ native({fold, Limiter, FoldObjectsFun, InitAcc, Elements}, _From, State) ->
 native(startup_metadata, _From, State) ->
     {reply, 
         {State#state.last_rebuild, false}, 
-        native};
+        native,
+        State};
 native(close, _From, State) ->
     {stop, normal, ok, State}.
 

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -946,7 +946,7 @@ logs() ->
         {"KS006",
             {warn, "Pending store is garbage and should be deleted at ~s"}},
         {"KS007",
-            {info, "Rebuild prompt ~w with GUID ~w"}}
+            {info, "Rebuild prompt ~w with GUID ~s"}}
 
         ].
 

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -263,11 +263,8 @@ handle_cast(destroy, State) ->
     aae_util:log("C0004", [State#state.partition_id], logs()),
     {stop, normal, State}.
 
-handle_info({'EXIT', FromPID, _Reason}, State) ->
-    aae_util:log("C0007", [FromPID], logs()),
-    save_to_disk(State#state.root_path, 
-                    State#state.save_sqn, 
-                    State#state.tree),
+
+handle_info(_Info, State) ->
     {stop, normal, State}.
 
 terminate(_Reason, _State) ->
@@ -660,7 +657,8 @@ get_leaf(AAECache0, BranchID, LeafID) ->
 
 
 coverage_cheat_test() ->
-    {ok, _State1} = code_change(null, #state{}, null).
+    {ok, _State1} = code_change(null, #state{}, null),
+    {stop, normal, _State2} = handle_info({'EXIT', self(), "Test"}, #state{}).
 
 
 test_setup_funs(InitialKeys) ->

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -224,8 +224,8 @@ handle_cast({complete_load, Tree}, State=#state{loading=Loading})
                                     {CH, OH}, 
                                     fun binary_extractfun/2)
         end,
-    Tree0 = 
-        lists:foldl(LoadFun, Tree, lists:reverse(State#state.change_queue)),
+    Tree0 = lists:foldr(LoadFun, Tree, State#state.change_queue),
+    aae_util:log("C0008", [length(State#state.change_queue)], logs()),
     {noreply, State#state{loading = false, change_queue = [], tree = Tree0}};
 handle_cast({mark_dirtysegments, SegmentList, FoldGUID}, State) ->
     case State#state.loading of 
@@ -398,7 +398,8 @@ logs() ->
         {"C0004", {info, "Destroying tree cache for partition ~w"}},
         {"C0005", {info, "Starting cache with is_restored=~w and IndexN of ~w"}},
         {"C0006", {debug, "Altering segment for PartitionID=~w ID=~w Hash=~w"}},
-        {"C0007", {warn, "Treecache exiting after trapping exit from Pid=~w"}}].
+        {"C0007", {warn, "Treecache exiting after trapping exit from Pid=~w"}},
+        {"C0008", {info, "Complete load of tree with length of change_queue=~w"}}].
 
 %%%============================================================================
 %%% Test

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -214,7 +214,9 @@ handle_cast({alter, Key, CurrentHash, OldHash}, State) ->
 handle_cast(start_load, State=#state{loading=Loading}) 
                                                     when Loading == false ->
     {noreply, 
-        State#state{loading = true, change_queue = [], dirty_segments = []}};
+        State#state{loading = true, 
+                    change_queue = [], dirty_segments = [], 
+                    active_fold = undefined}};
 handle_cast({complete_load, Tree}, State=#state{loading=Loading}) 
                                                     when Loading == true ->
     LoadFun = 

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -73,14 +73,14 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
 
     {ok, Cntrl1} = 
         aae_controller:aae_start({parallel, StoreType}, 
-                                    {true, none}, 
+                                    true, 
                                     {1, 300}, 
                                     [{2, 0}, {2, 1}], 
                                     VnodePath1, 
                                     SplitF),
     {ok, Cntrl2} = 
         aae_controller:aae_start({parallel, StoreType}, 
-                                    {true, none}, 
+                                    true, 
                                     {1, 300}, 
                                     [{3, 0}, {3, 1}, {3, 2}], 
                                     VnodePath2, 
@@ -258,8 +258,8 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                 [timer:now_diff(os:timestamp(), SW2)/1000]),
 
     % Shutdown and tidy up
-    ok = aae_controller:aae_close(Cntrl1, none),
-    ok = aae_controller:aae_close(Cntrl2, none),
+    ok = aae_controller:aae_close(Cntrl1),
+    ok = aae_controller:aae_close(Cntrl2),
     RootPath = reset_filestructure().
 
 

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -389,7 +389,8 @@ handle_cast({rebuild_complete, store}, State) ->
     ok = aae_controller:aae_rebuildtrees(State#state.aae_controller, 
                                             State#state.index_ns,
                                             State#state.preflist_fun,
-                                            Worker),
+                                            Worker,
+                                            false),
 
     {noreply, State#state{aae_rebuild = true}};
 handle_cast({rebuild_complete, tree}, State) ->

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -61,9 +61,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(BUCKET_SDG, <<"MD">>).
--define(KEY_SDG, <<"SHUDOWN_GUID">>).
--define(TAG_SDG, o).
 -define(RIAK_TAG, o_rkv).
 -define(REBUILD_SCHEDULE, {1, 60}).
 -define(LASTMOD_LEN, 29). 
@@ -165,17 +162,6 @@ init([Opts]) ->
     RP = Opts#options.root_path,
     {ok, VnSt} = 
         leveled_bookie:book_start(RP, 4000, 100000000, none),
-    ShutdownGUID = 
-        case leveled_bookie:book_get(VnSt, ?BUCKET_SDG, ?KEY_SDG, ?TAG_SDG) of
-            not_found ->
-                none;
-            {ok, Value} when is_list(Value) ->
-                ok = leveled_bookie:book_delete(VnSt, 
-                                                ?BUCKET_SDG, 
-                                                ?KEY_SDG, 
-                                                []),
-                Value
-        end,
     IsEmpty = leveled_bookie:book_isempty(VnSt, ?RIAK_TAG),
     KeyStoreType = 
         case Opts#options.aae of 
@@ -186,7 +172,7 @@ init([Opts]) ->
         end,
     {ok, AAECntrl} = 
         aae_controller:aae_start(KeyStoreType, 
-                                    {IsEmpty, ShutdownGUID}, 
+                                    IsEmpty, 
                                     ?REBUILD_SCHEDULE, 
                                     Opts#options.index_ns, 
                                     RP, 
@@ -361,13 +347,7 @@ handle_call({fold_aae, Limiter, FoldFun, InitAcc, Elements}, _From, State) ->
                                 Elements),
     {reply, R, State};
 handle_call(close, _From, State) ->
-    ShutdownGUID = leveled_util:generate_uuid(),
-    ok = leveled_bookie:book_put(State#state.vnode_store, 
-                                    ?BUCKET_SDG, ?KEY_SDG, 
-                                    ShutdownGUID, [], 
-                                    ?TAG_SDG),
-    ok = leveled_bookie:book_close(State#state.vnode_store),
-    ok = aae_controller:aae_close(State#state.aae_controller, ShutdownGUID),
+    ok = aae_controller:aae_close(State#state.aae_controller),
     {stop, normal, ok, State}.
 
 handle_cast({push, Bucket, Key, UpdClock, ObjectBin, IndexN}, State) ->


### PR DESCRIPTION
This resolves a number of issues thrown up through real-world testing inside of Riak.

This changes the shutdown behaviour, to stop the unnecessary coordination through a shutdown GUID .  It also ensures that clocks are sorted before hashing to avoid accidental inconsistencies.  It reflects the changes made to leveled to strengthen the API around head_only mode.