### PR TITLE
Mas i42 treeexchange

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i207-althashkey"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "master"}}}
         ]}.

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -1455,6 +1455,15 @@ rebuild_worker(ReturnFun) ->
             ReturnFun(ok)
     end.
 
+wrap_splitfun_test() ->
+    SplitObjFun = 
+        fun(_Obj) -> {1000, 2, 0, term_to_binary(null)} end,
+    WrappedFun = wrapped_splitobjfun(SplitObjFun),
+    SplitObj = WrappedFun(null),
+    ?assertMatch(true, is_tuple(SplitObj)),
+    ?assertMatch(5, tuple_size(SplitObj)),
+    ?assertMatch(undefined, element(4, SplitObj)). 
+
 -endif.
 
 

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -1,11 +1,13 @@
 %% -------- Overview ---------
 %%
 %% There are two primary types of exchange sorted
-%% - a multipart exchange aimed at implementations with cached trees
-%% - a tree exchange where it is expected that the tree will be dynamically
-%% calculated
+%% - a full exchange aimed at implementations with cached trees, where the
+%% cached trees represent all the data in the location, and the comparion is
+%% between two complete data sets
+%% - a partial exchange where it is expected that trees will be dynamically
+%% created covering a subset of data within the location
 %%
-%% The multipart exchange assumes access to cached trees, with a low cost of
+%% The full exchange assumes access to cached trees, with a low cost of
 %% repeated access, and a relatively high proportion fo the overall cost in
 %% network bandwitdh.  These exchanges go through the following process:
 %%
@@ -16,10 +18,10 @@
 %% - Clock Compare
 %% - Repair
 %%
-%% The dynamic tree exchange is based on dynamically produced trees, where a
-%% relatively high proportion of the cost is in the production of the trees.
-%% In a tree exchange, whole trees are compared (potentially reduced by use
-%% of a segment filter), until the delta stops decreasing at a significant
+%% The partial, dynamic tree exchange is based on dynamically produced trees,
+%% where a relatively high proportion of the cost is in the production of the
+%% trees. In a tree exchange, whole trees are compared (potentially reduced by
+%% use of a segment filter), until the delta stops decreasing at a significant
 %% rate and a Clock Compare is run.  So these exchanges for through the
 %% following process:
 %%
@@ -104,8 +106,21 @@
     % 60 seconds (used in fetch root/branches)
 -define(SCAN_TIMEOUT_MS, 600000). 
     % 10 minutes (used in fetch clocks)
+-define(UNFILTERED_SCAN_TIMEOUT_MS, 3600000).
+    % 60 minutes (used in fetch trees with no filters)
 -define(MAX_RESULTS, 128). 
-    % Maximum number of results to request in one round of 
+    % Maximum number of results to request in one round of
+-define(WORTHWHILE_REDUCTION, 0.3).
+    % If the last comparison of trees has reduced the size of the dirty leaves
+    % by 30%, probably worth comparing again before a clock fetch is run. 
+    % Number a suck-teeth estimate, not even a fag-packet calculation involved.
+-define(WORTHWHILE_FILTER, 256).
+    % If the number of segment IDs to pass into a filter is too large, the
+    % filter is probably not worthwhile - more effort checking the filter, than
+    % time saved in the accumulator.  Another suck-teeth estimate here as to
+    % what this value is, at this level with a small tree it will save opening
+    % all but one block in most slots (with the sst file).  I suspect the
+    % optimal number is more likely to be higher than lower.
 
 -export([init/1,
             handle_sync_event/4,
@@ -115,16 +130,19 @@
             code_change/4]).
 
 -export([waiting_all_results/2,
-            prepare/2,
+            prepare_full_exchange/2,
+            prepare_partial_exchange/2,
             root_compare/2,
             root_confirm/2,
             branch_compare/2,
             branch_confirm/2,
             clock_compare/2,
+            tree_compare/2,
             merge_root/2,
             merge_branches/2]).
 
 -export([start/4,
+            start/6,
             reply/3]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -133,6 +151,7 @@
                 root_confirm_deltas = [] :: list(),
                 branch_compare_deltas = [] :: list(),
                 branch_confirm_deltas = [] :: list(),
+                tree_compare_deltas = [] :: list(),
                 key_deltas = [] :: list(),
                 repair_fun,
                 reply_fun,
@@ -146,21 +165,47 @@
                 merge_fun,
                 start_time = os:timestamp() :: erlang:timestamp(),
                 pending_state :: atom(),
-                reply_timeout = 0 :: integer()
+                reply_timeout = 0 :: integer(),
+                exchange_type :: exchange_type(),
+                exchange_filters = none :: filters(),
+                last_tree_compare = none :: list(non_neg_integer())|none,
+                tree_compares = 0 :: integer()
                 }).
 
--type input_list() :: [{fun(), list(tuple())}].
+-type input_list() :: [{fun(), list(tuple())|all}].
     % The Blue List and the Pink List are made up of:
     % - a SendFun, which should  be a 3-arity function, taking a preflist, 
     % a message and a colour to be used to flag the reply;
     % - a list of preflists, to be used in the SendFun to be filtered by the
     % target.  The Preflist might be {Index, Node} for remote requests or 
     % {Index, Pid} for local requests
+    % For partial exchanges only, the preflist can and must be set to 'all'
 -type branch_results() :: list({integer(), binary()}).
     % Results to branch queries are a list mapping Branch ID to the binary for
     % that branch
 -type exchange_state() :: #state{}.
--type exchange_type() :: multipart|tree.
+-type exchange_type() :: full|partial.
+
+-type bucket() :: 
+    {binary(), binary()}|binary().
+-type key_range() :: 
+    {binary(), binary()}|all.
+-type modified_range() :: 
+    {non_neg_integer(), non_neg_integer()}|all.
+-type segment_filter() :: 
+    {segments, list(non_neg_integer()), leveled_tictac:tree_size()}|all.
+-type hash_method() ::
+    pre_hash|{rehash, non_neg_integer()}.
+-type filters() :: 
+    {filter,
+        bucket(), key_range(),
+        leveled_tictac:tree_size(),
+        segment_filter(), modified_range(),
+        hash_method()}|none.
+    % filter to be used in partial exchanges
+
+-define(FILTERIDX_SEG, 5).
+-define(FILTERIDX_TRS, 4).
 
 %%%============================================================================
 %%% API
@@ -169,11 +214,12 @@
 
 start(BlueList, PinkList, RepairFun, ReplyFun) ->
     % API for backwards compatability
-    start(multipart, BlueList, PinkList, RepairFun, ReplyFun).
+    start(full, BlueList, PinkList, RepairFun, ReplyFun, none).
 
 
--spec start(exchange_type(), input_list(), input_list(), fun(), fun())
-                                                        -> {ok, pid(), list()}.
+-spec start(exchange_type(),
+            input_list(), input_list(), fun(), fun(),
+            filters()) -> {ok, pid(), list()}.
 %% @doc
 %% Start an FSM to manage an exchange and comapre the preflsist in the 
 %% BlueList with those in the PinkList, using the RepairFun to repair any
@@ -181,13 +227,23 @@ start(BlueList, PinkList, RepairFun, ReplyFun) ->
 %% to calling client the StateName at termination.
 %%
 %% The ReplyFun should be a 1 arity function t
-start(_ExchangeType, BlueList, PinkList, RepairFun, ReplyFun) ->
+start(full, BlueList, PinkList, RepairFun, ReplyFun, none) ->
     ExchangeID = leveled_util:generate_uuid(),
     {ok, ExPID} = gen_fsm:start(?MODULE, 
-                                [BlueList, PinkList, RepairFun, ReplyFun, 
+                                [{full, none}, 
+                                    BlueList, PinkList, RepairFun, ReplyFun,
+                                    ExchangeID], 
+                                []),
+    {ok, ExPID, ExchangeID};
+start(partial, BlueList, PinkList, RepairFun, ReplyFun, Filters) ->
+    ExchangeID = leveled_util:generate_uuid(),
+    {ok, ExPID} = gen_fsm:start(?MODULE, 
+                                [{partial, Filters}, 
+                                    BlueList, PinkList, RepairFun, ReplyFun,
                                     ExchangeID], 
                                 []),
     {ok, ExPID, ExchangeID}.
+
 
 -spec reply(pid(), any(), pink|blue) -> ok.
 %% @doc
@@ -199,7 +255,7 @@ reply(Exchange, Result, Colour) ->
 %%% gen_fsm callbacks
 %%%============================================================================
 
-init([BlueList, PinkList, RepairFun, ReplyFun, ExchangeID]) ->
+init([{full, none}, BlueList, PinkList, RepairFun, ReplyFun, ExChID]) ->
     leveled_rand:seed(),
     PinkTarget = length(PinkList),
     BlueTarget = length(BlueList),
@@ -207,20 +263,54 @@ init([BlueList, PinkList, RepairFun, ReplyFun, ExchangeID]) ->
                     pink_list = PinkList,
                     repair_fun = RepairFun,
                     reply_fun = ReplyFun,
-                    exchange_id = ExchangeID,
+                    exchange_id = ExChID,
                     pink_returns = {PinkTarget, PinkTarget},
-                    blue_returns = {BlueTarget, BlueTarget}},
-    aae_util:log("EX001", [ExchangeID, PinkTarget + BlueTarget], logs()),
-    {ok, prepare, State, 0}.
+                    blue_returns = {BlueTarget, BlueTarget},
+                    exchange_type = full},
+    aae_util:log("EX001", [ExChID, PinkTarget + BlueTarget], logs()),
+    {ok, prepare_full_exchange, State, 0};
+init([{partial, Filters}, BlueList, PinkList, RepairFun, ReplyFun, ExChID]) ->
+    leveled_rand:seed(),
+    PinkTarget = length(PinkList),
+    BlueTarget = length(BlueList),
+    State = #state{blue_list = BlueList, 
+                    pink_list = PinkList,
+                    repair_fun = RepairFun,
+                    reply_fun = ReplyFun,
+                    exchange_id = ExChID,
+                    pink_returns = {PinkTarget, PinkTarget},
+                    blue_returns = {BlueTarget, BlueTarget},
+                    exchange_type = partial,
+                    exchange_filters = Filters},
+    aae_util:log("EX001", [ExChID, PinkTarget + BlueTarget], logs()),
+    {ok, prepare_partial_exchange, State, 0}.
 
-prepare(timeout, State) ->
-    aae_util:log("EX006", [prepare, State#state.exchange_id], logs()),
+
+prepare_full_exchange(timeout, State) ->
+    aae_util:log("EX006",
+                    [prepare_tree_exchange, State#state.exchange_id],
+                    logs()),
     trigger_next(fetch_root, 
                     root_compare, 
                     fun merge_root/2, 
                     <<>>, 
                     false, 
                     ?CACHE_TIMEOUT_MS, 
+                    State).
+
+prepare_partial_exchange(timeout, State) ->
+    aae_util:log("EX006",
+                    [prepare_partial_exchange, State#state.exchange_id],
+                    logs()),
+    Filters = State#state.exchange_filters,
+    ScanTimeout = filtered_timeout(Filters),
+    TreeSize = element(?FILTERIDX_TRS, Filters),
+    trigger_next({merge_tree_range, Filters},
+                    tree_compare,
+                    fun merge_tree/2,
+                    leveled_tictac:new_tree(empty_tree, TreeSize),
+                    false,
+                    ScanTimeout,
                     State).
 
 root_compare(timeout, State) ->
@@ -233,6 +323,66 @@ root_compare(timeout, State) ->
                     length(BranchIDs) == 0, 
                     ?CACHE_TIMEOUT_MS, 
                     State#state{root_compare_deltas = BranchIDs}).
+
+tree_compare(timeout, State) ->
+    aae_util:log("EX006", [root_compare, State#state.exchange_id], logs()),
+    DirtyLeaves = compare_trees(State#state.blue_acc, State#state.pink_acc),
+    TreeCompares = State#state.tree_compares + 1,
+    {StillDirtyLeaves, Reduction} = 
+        case State#state.last_tree_compare of
+            none ->
+                {DirtyLeaves, 1.0};
+            PreviouslyDirtyLeaves ->
+                SDL = intersect_ids(PreviouslyDirtyLeaves, DirtyLeaves),
+                {SDL, 1.0 - length(SDL) / length(PreviouslyDirtyLeaves)}
+        end,
+    % We want to keep comparing trees until the number of deltas stops reducing
+    % significantly.  Then there should be a clock comparison.
+    % It is expected there will be natural deltas with tree compare because of
+    % timing differences.  Ideally the natural deltas will be small enough so
+    % that there should be no more than 2 tree compares before a segment filter
+    % can be applied to accelerate the process.
+    case ((length(StillDirtyLeaves) > 0)
+            and (Reduction > ?WORTHWHILE_REDUCTION)) of
+        true ->
+            % Keep comparing trees, this is reducing the segments we will
+            % eventually need to compare
+            Filters = State#state.exchange_filters,
+            TreeSize = element(?FILTERIDX_TRS, Filters),
+            Filters0 =
+                case length(StillDirtyLeaves) < ?WORTHWHILE_FILTER of
+                    true ->
+                        Segments =
+                            {segments, StillDirtyLeaves, TreeSize},
+                        setelement(?FILTERIDX_SEG, Filters, Segments);
+                    false ->
+                        Filters
+                end,
+            ScanTimeout = filtered_timeout(Filters0),
+            trigger_next({merge_tree_range, Filters0},
+                            tree_compare,
+                            fun merge_tree/2,
+                            leveled_tictac:new_tree(empty_tree, TreeSize),
+                            false,
+                            ScanTimeout,
+                            State#state{last_tree_compare = StillDirtyLeaves,
+                                        tree_compares = TreeCompares});
+        false ->
+            % Compare clocks.  Note if there are no Mismatched segment IDs the
+            % stop condition in trigger_next will be met
+            SegmentIDs = select_ids(StillDirtyLeaves, 
+                                    ?MAX_RESULTS,
+                                    tree_compare, 
+                                    State#state.exchange_id),
+            trigger_next({fetch_clocks, SegmentIDs}, 
+                            clock_compare, 
+                            fun merge_clocks/2, 
+                            [],
+                            length(SegmentIDs) == 0, 
+                            ?SCAN_TIMEOUT_MS, 
+                            State#state{tree_compare_deltas = StillDirtyLeaves,
+                                        tree_compares = TreeCompares})
+    end.
 
 root_confirm(timeout, State) ->
     aae_util:log("EX006", [root_confirm, State#state.exchange_id], logs()),
@@ -341,14 +491,26 @@ handle_info(_Msg, StateName, State) ->
     {next_state, StateName, State}.
 
 terminate(normal, StateName, State) ->
-    aae_util:log("EX003", 
-                    [StateName, State#state.exchange_id,
-                        length(State#state.root_compare_deltas),
-                        length(State#state.root_confirm_deltas),
-                        length(State#state.branch_compare_deltas),
-                        length(State#state.branch_confirm_deltas),
-                        length(State#state.key_deltas)], 
-                    logs()),
+    case State#state.exchange_type of
+        full ->
+            aae_util:log("EX003", 
+                            [StateName,
+                                State#state.exchange_id,
+                                length(State#state.root_compare_deltas),
+                                length(State#state.root_confirm_deltas),
+                                length(State#state.branch_compare_deltas),
+                                length(State#state.branch_confirm_deltas),
+                                length(State#state.key_deltas)], 
+                            logs());
+        partial ->
+            aae_util:log("EX009", 
+                            [StateName,
+                                State#state.exchange_id,
+                                length(State#state.tree_compare_deltas),
+                                State#state.tree_compares,
+                                length(State#state.key_deltas)], 
+                            logs())
+    end,
     ReplyFun = State#state.reply_fun,
     ReplyFun({StateName, length(State#state.key_deltas)}).
 
@@ -399,6 +561,13 @@ merge_branches([{BranchID, BranchBin}|Rest], BranchAccL) ->
 %% binary for the tree root
 merge_root(Root, RootAcc) ->
     merge_binary(Root, RootAcc).
+
+-spec merge_tree(leveled_tictac:tictactree(), leveled_tictac:tictactree())
+                                                -> leveled_tictac:tictactree().
+%% @doc
+%% Merge two trees into an XOR'd tree representing the total result set
+merge_tree(Tree0, Tree1) ->
+    leveled_tictac:merge_trees(Tree0, Tree1).
 
 %%%============================================================================
 %%% Internal Functions
@@ -556,6 +725,13 @@ compare_clocks(BlueList, PinkList) ->
     AllDeltaList.
 
 
+-spec compare_trees(leveled_tictac:tictactree(),
+                    leveled_tictac:tictactree()) -> list(non_neg_integer()).
+%% @doc
+%% Compare the trees - get list of dirty leaves (Segment IDs)
+compare_trees(Tree0, Tree1) ->
+    leveled_tictac:find_dirtyleaves(Tree0, Tree1).
+
 -spec intersect_ids(list(integer()), list(integer())) -> list(integer()).
 %% @doc
 %% Provide the intersection of two lists of integer IDs
@@ -611,6 +787,18 @@ jitter_pause(Timeout) ->
 %% Rest the count back to 0
 reset({Target, Target}) -> {0, Target}. 
 
+-spec filtered_timeout(filters()) -> pos_integer().
+%% @doc
+%% Has a filter been applied to the scan (true), or are we scanning the whole
+%% bucket (false)
+filtered_timeout({filter, _B, KeyRange, _TS, SegFilter, ModRange, _HM}) ->
+    case ((KeyRange == all) and (SegFilter == all) and (ModRange == all)) of
+        true ->
+            ?UNFILTERED_SCAN_TIMEOUT_MS;
+        false ->
+            ?SCAN_TIMEOUT_MS
+    end.
+
 %%%============================================================================
 %%% log definitions
 %%%============================================================================
@@ -625,7 +813,8 @@ logs() ->
             {error, "Timeout with pending_state=~w and missing_count=~w" 
                         ++ " for exchange id=~s"}},
         {"EX003",
-            {info, "Normal exit at pending_state=~w for exchange id=~s"
+            {info, "Normal exit for full exchange at"
+                        ++ " pending_state=~w for exchange_id=~s"
                         ++ " root_compare_deltas=~w root_confirm_deltas=~w"
                         ++ " branch_compare_deltas=~w branch_confirm_deltas=~w"
                         ++ " key_deltas=~w"}},
@@ -638,7 +827,12 @@ logs() ->
         {"EX007", 
             {debug, "Reply received for colour=~w in exchange id=~s"}},
         {"EX008", 
-            {debug, "Comparison between BlueList ~w and PinkList ~w"}}
+            {debug, "Comparison between BlueList ~w and PinkList ~w"}},
+        {"EX009",
+            {info, "Normal exit for partial (dynamic) exchange at"
+                        ++ " pending_state=~w for exchange_id=~s"
+                        ++ " tree_compare_deltas=~w after tree_compares=~w"
+                        ++ " key_deltas=~w"}}
         ].
 
 
@@ -687,16 +881,21 @@ compare_clocks_test() ->
                     compare_clocks(BL1, PL2)).
 
 clean_exit_ontimeout_test() ->
-    State0 = #state{pink_returns={4, 5}, blue_returns={8, 8}},
+    State0 = #state{pink_returns={4, 5}, blue_returns={8, 8},
+                    exchange_type = full},
     State1 = State0#state{pending_state = timeout},
     {stop, normal, State1} = waiting_all_results(timeout, State0).
 
 
 coverage_cheat_test() ->
-    {next_state, prepare, _State0} = handle_event(null, prepare, #state{}),
-    {reply, ok, prepare, _State1} = handle_sync_event(null, nobody, prepare, #state{}),
-    {next_state, prepare, _State2} = handle_info(null, prepare, #state{}),
-    {ok, prepare, _State3} = code_change(null, prepare, #state{}, null).
+    {next_state, prepare, _State0} =
+        handle_event(null, prepare, #state{exchange_type = full}),
+    {reply, ok, prepare, _State1} =
+        handle_sync_event(null, nobody, prepare, #state{exchange_type = full}),
+    {next_state, prepare, _State2} =
+        handle_info(null, prepare, #state{exchange_type = full}),
+    {ok, prepare, _State3} =
+        code_change(null, prepare, #state{exchange_type = full}, null).
 
 
 -endif.

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -699,7 +699,7 @@ compare_clocks(BlueList, PinkList) ->
         % Want to subtract out from the Pink and Blue Sets any example where 
         % both pink and blue are the same
         %
-        % This should spped up the foling and key finding to provide the 
+        % This should speed up the folding and key finding to provide the 
         % joined list
 
     BlueDeltaList = 

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -993,7 +993,7 @@ range_check(all, _B, _K) ->
 range_check({buckets, BucketList}, Bucket, _K) ->
     lists:member(Bucket, BucketList);
 range_check({key_range, Bucket, StartKey, EndKey}, Bucket, Key) ->
-    case {Key >= StartKey, Key < EndKey} of
+    case {Key >= StartKey, Key =< EndKey} of
         {true, true} ->
             true;
         _ ->

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -4,46 +4,14 @@
 -export([dual_store_compare_medium_so/1,
             dual_store_compare_medium_ko/1,
             dual_store_compare_large_so/1,
-            dual_store_compare_large_ko/1,
-            mock_vnode_loadexchangeandrebuild_stbucket/1,
-            mock_vnode_loadexchangeandrebuild_tuplebucket/1,
-            aae_fold_keyorder/1,
-            aae_fold_segmentorder/1,
-            mock_vnode_coveragefold_nativemedium/1,
-            mock_vnode_coveragefold_nativesmall/1,
-            mock_vnode_coveragefold_parallelmedium/1,
-            mock_vnode_coveragefold_parallelsmall/1]).
+            dual_store_compare_large_ko/1]).
 
 all() -> [dual_store_compare_medium_so,
             dual_store_compare_medium_ko,
             dual_store_compare_large_so,
-            dual_store_compare_large_ko,
-            mock_vnode_loadexchangeandrebuild_stbucket,
-            mock_vnode_loadexchangeandrebuild_tuplebucket,
-            aae_fold_keyorder,
-            aae_fold_segmentorder,
-            mock_vnode_coveragefold_nativemedium,
-            mock_vnode_coveragefold_nativesmall,
-            mock_vnode_coveragefold_parallelmedium,
-            mock_vnode_coveragefold_parallelsmall
+            dual_store_compare_large_ko
         ].
-
--define(ROOT_PATH, "test/").
--define(BUCKET_TYPE, <<"BucketType">>).
-
--record(r_content, {
-                    metadata,
-                    value :: term()
-                    }).
-
--record(r_object, {
-                    bucket,
-                    key,
-                    contents :: [#r_content{}],
-                    vclock = [],
-                    updatemetadata=dict:store(clean, true, dict:new()),
-                    updatevalue :: term()}).
-
+    
 
 dual_store_compare_medium_so(_Config) ->
     dual_store_compare_tester(10000, leveled_so).
@@ -72,7 +40,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     % Don't rtry and make sense of this in term of a ring - the 
     % mock_vnode_coverage_fold tests have a more Riak ring-like setup.
 
-    RootPath = reset_filestructure(),
+    RootPath = testutil:reset_filestructure(),
     VnodePath1 = filename:join(RootPath, "vnode1/"),
     VnodePath2 = filename:join(RootPath, "vnode2/"),
     SplitF = fun(_X) -> {leveled_rand:uniform(1000), 1, 0, null} end,
@@ -102,31 +70,31 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     ok = aae_controller:aae_mergeroot(Cntrl1, 
                                         [{2, 0}, {2, 1}], 
                                         ReturnFun),
-    Root1A = start_receiver(),
+    Root1A = testutil:start_receiver(),
     ok = aae_controller:aae_mergeroot(Cntrl2, 
                                         [{3, 0}, {3, 1}, {3, 2}], 
                                         ReturnFun),
-    Root2A = start_receiver(),
+    Root2A = testutil:start_receiver(),
     true = Root1A == Root2A,
 
     ok = aae_controller:aae_fetchroot(Cntrl1, 
                                         [{2, 0}], 
                                         ReturnFun),
-    [{{2, 0}, Root1B}] = start_receiver(),
+    [{{2, 0}, Root1B}] = testutil:start_receiver(),
     ok = aae_controller:aae_fetchroot(Cntrl2, 
                                         [{3, 0}], 
                                         ReturnFun),
-    [{{3, 0}, Root2B}] = start_receiver(),
+    [{{3, 0}, Root2B}] = testutil:start_receiver(),
     true = Root1B == Root2B,
 
     ok = aae_controller:aae_mergeroot(Cntrl1, 
                                         [{2, 1}], 
                                         ReturnFun),
-    Root1C = start_receiver(),
+    Root1C = testutil:start_receiver(),
     ok = aae_controller:aae_mergeroot(Cntrl2, 
                                         [{3, 1}, {3, 2}], 
                                         ReturnFun),
-    Root2C = start_receiver(),
+    Root2C = testutil:start_receiver(),
     true = Root1C == Root2C,
     
     io:format("Direct partition compare complete in ~w ms~n", 
@@ -181,7 +149,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID1]),
-    {ExchangeState1, 0} = start_receiver(),
+    {ExchangeState1, 0} = testutil:start_receiver(),
     true = ExchangeState1 == root_compare,
 
     {ok, _P2, GUID2} = 
@@ -190,7 +158,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID2]),
-    {ExchangeState2, 0} = start_receiver(),
+    {ExchangeState2, 0} = testutil:start_receiver(),
     true = ExchangeState2 == root_compare,
 
     {ok, _P3, GUID3} = 
@@ -200,7 +168,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID3]),
-    {ExchangeState3, 0} = start_receiver(),
+    {ExchangeState3, 0} = testutil:start_receiver(),
     true = ExchangeState3 == root_compare,
 
     {ok, _P4, GUID4} = 
@@ -211,7 +179,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID4]),
-    {ExchangeState4, 0} = start_receiver(),
+    {ExchangeState4, 0} = testutil:start_receiver(),
     true = ExchangeState4 == root_compare,
 
     BKVListN = create_discrepancy(Cntrl1, InitialKeyCount),
@@ -224,7 +192,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID6]),
-    {ExchangeState6, 10} = start_receiver(),
+    {ExchangeState6, 10} = testutil:start_receiver(),
     true = ExchangeState6 == clock_compare,
 
     % Same again, but request a missing partition, and should get same result
@@ -237,13 +205,13 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID6a]),
-    {ExchangeState6a, 10} = start_receiver(),
+    {ExchangeState6a, 10} = testutil:start_receiver(),
     true = ExchangeState6a == clock_compare,
 
     % Nothing repaired last time.  The deltas are all new keys though, so
     % We can repair by adding them in to the other vnode
 
-    RepairFun0 = repair_fun(BKVListN, Cntrl2, 3),
+    RepairFun0 = testutil:repair_fun(BKVListN, Cntrl2, 3),
     {ok, _P7, GUID7} = 
         aae_exchange:start([{exchange_sendfun(Cntrl1), [{2,0}]}, 
                                     {exchange_sendfun(Cntrl1), [{2,1}]}],
@@ -252,7 +220,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun0,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID7]),
-    {ExchangeState7, 10} = start_receiver(),
+    {ExchangeState7, 10} = testutil:start_receiver(),
     true = ExchangeState7 == clock_compare,
     
     {ok, _P8, GUID8} = 
@@ -263,7 +231,7 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
                                 RepairFun,
                                 ReturnFun),
     io:format("Exchange id ~s~n", [GUID8]),
-    {ExchangeState8, 0} = start_receiver(),
+    {ExchangeState8, 0} = testutil:start_receiver(),
     true = ExchangeState8 == root_compare,
 
     io:format("Comparison through exchange complete in ~w ms~n", 
@@ -272,1018 +240,32 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     % Shutdown and tidy up
     ok = aae_controller:aae_close(Cntrl1),
     ok = aae_controller:aae_close(Cntrl2),
-    RootPath = reset_filestructure().
-
-
-aae_fold_keyorder(_Config) ->
-    aae_fold_tester(leveled_ko, 50000).
-
-aae_fold_segmentorder(_Config) ->
-    aae_fold_tester(leveled_so, 50000).
-
-
-aae_fold_tester(ParallelStoreType, KeyCount) ->
-    RootPath = reset_filestructure(),
-    FoldPath1 = filename:join(RootPath, "folder1/"),
-    SplitF = 
-        fun(X) -> 
-            {leveled_rand:uniform(1000), 1, 0, element(1, X), element(2, X)}
-        end,
-    
-    {ok, Cntrl1} = 
-        aae_controller:aae_start({parallel, ParallelStoreType}, 
-                                    true, 
-                                    {1, 300}, 
-                                    [{2, 0}, {2, 1}], 
-                                    FoldPath1, 
-                                    SplitF),
-
-    BKVListXS = gen_keys([], KeyCount),
-    
-    {SWLowMegaS, SWLowS, _SWLowMicroS} = os:timestamp(),
-    timer:sleep(1000),
-    ok = put_keys(Cntrl1, 2, BKVListXS, none),
-    timer:sleep(1000),
-    {SWHighMegaS, SWHighS, _SWHighMicroS} = os:timestamp(),
-    BucketList = [integer_to_binary(1), integer_to_binary(3)],
-    FoldElements = [{clock, null}, {md, null}],
-    FoldFun =
-        fun(B, _K, ElementList, {B1Count, B3Count}) ->
-            {clock, FoldClock} = lists:keyfind(clock, 1, ElementList),
-            {md, FoldMD} = lists:keyfind(md, 1, ElementList),
-            case binary_to_term(FoldMD) of
-                [{clock, FoldClock}] ->
-                    case B of
-                        <<"1">> ->
-                            {B1Count + 1, B3Count};
-                        <<"3">> ->
-                            {B1Count, B3Count + 1}
-                    end
-            end
-        end,
-    InitAcc = {0, 0},
-    {async, Runner1} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                all,
-                                all,
-                                false,
-                                FoldFun,
-                                InitAcc,
-                                FoldElements),
-    true = {KeyCount div 5, KeyCount div 5} == Runner1(),
-
-    {async, Runner2} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                all,
-                                {SWLowMegaS * 1000000 + SWLowS,
-                                    SWHighMegaS * 1000000 + SWHighS},
-                                false,
-                                FoldFun,
-                                InitAcc,
-                                FoldElements),
-    true = {KeyCount div 5, KeyCount div 5} == Runner2(),
-
-    {async, Runner3} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                all,
-                                {0, SWLowMegaS * 1000000 + SWLowS},
-                                false,
-                                FoldFun,
-                                InitAcc,
-                                FoldElements),
-    
-    {0, 0} = Runner3(),
-
-    {async, Runner4} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                all,
-                                {SWHighMegaS * 1000000 + SWHighS, 
-                                    infinity},
-                                false,
-                                FoldFun,
-                                InitAcc,
-                                FoldElements),
-    {0, 0} = Runner4(),
-    
-    {async, Runner5} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                all,
-                                all,
-                                2000,
-                                FoldFun,
-                                InitAcc,
-                                FoldElements),
-    case ParallelStoreType of
-        leveled_ko ->
-            {0, {2000, 0}} = Runner5();
-        leveled_so ->
-            true = 
-                {-1, {KeyCount div 5, KeyCount div 5}} == Runner5()
-    end,
-
-    {async, Runner6} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                all,
-                                {SWLowMegaS * 1000000 + SWLowS,
-                                    SWHighMegaS * 1000000 + SWHighS},
-                                2000,
-                                FoldFun,
-                                InitAcc,
-                                FoldElements),
-    case ParallelStoreType of
-        leveled_ko ->
-            {0, {2000, 0}} = Runner6();
-        leveled_so ->
-            true = 
-                {-1, {KeyCount div 5, KeyCount div 5}} == Runner6()
-    end,
-
-    BKVSL = lists:sublist(BKVListXS, KeyCount - 1000, 128),
-    SegMapFun =
-        fun ({B, K, _VV}) ->
-            BinK = aae_util:make_binarykey(B, K),
-            Seg32 = leveled_tictac:keyto_segment32(BinK),
-            leveled_tictac:get_segment(Seg32, small)
-        end,
-    SegList = lists:map(SegMapFun, BKVSL),
-    BKVSL_ByBL =
-        lists:filter(fun({B, _K, _V}) -> lists:member(B, BucketList) end,
-                        BKVSL),
-    FoldClocksElements = [{clock, null}],
-    FoldClocksFun =
-        fun(B, K, ElementList, Acc) ->
-            {clock, FoldClock} = lists:keyfind(clock, 1, ElementList),
-            [{B, K, FoldClock}|Acc]
-        end,
-
-    {async, Runner7} = 
-        aae_controller:aae_fold(Cntrl1, 
-                                {buckets, BucketList},
-                                {segments, SegList, small},
-                                all,
-                                false,
-                                FoldClocksFun,
-                                [],
-                                FoldClocksElements),
-    
-    FetchedClocks = Runner7(),
-    io:format("Fetched ~w clocks with segment filter~n",
-                [length(FetchedClocks)]),
-    true = 
-        [] == lists:subtract(BKVSL_ByBL, FetchedClocks),
-        % Found all the Keys and clocks in the list
-    true =
-        (KeyCount div 64) > length(lists:subtract(FetchedClocks, BKVSL_ByBL)),
-        % Didn't find "too many" others due to collisions on segment
-
-    ok = aae_controller:aae_close(Cntrl1),
-    RootPath = reset_filestructure().
-
-
-mock_vnode_loadexchangeandrebuild_stbucket(_Config) ->
-    mock_vnode_loadexchangeandrebuild_tester(false).
-
-mock_vnode_loadexchangeandrebuild_tuplebucket(_Config) ->
-    mock_vnode_loadexchangeandrebuild_tester(true).
-
-mock_vnode_loadexchangeandrebuild_tester(TupleBuckets) ->
-    % Load up two vnodes with same data, with the data in each node split 
-    % across 3 partitions (n=1).
-    %
-    % The purpose if to perform exchanges to first highlight no differences, 
-    % and then once a difference is created, discover any difference 
-    InitialKeyCount = 50000,
-    RootPath = reset_filestructure(),
-    MockPathN = filename:join(RootPath, "mock_native/"),
-    MockPathP = filename:join(RootPath, "mock_parallel/"),
-
-    IndexNs = [{1, 3}, {2, 3}, {3, 3}],
-    PreflistFun = 
-        fun(_B, K) ->
-            Idx = erlang:phash2(K) rem length(IndexNs),
-            lists:nth(Idx + 1, IndexNs)
-        end,
-
-    % Start up to two mock vnodes
-    % - VNN is a native vnode (where the AAE process will not keep a parallel
-    % key store)
-    % - VNP is a parallel vnode (where a separate AAE key store is required 
-    % to be kept in parallel)
-    {ok, VNN} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
-    {ok, VNP} = mock_kv_vnode:open(MockPathP, parallel, IndexNs, PreflistFun),
-
-    RPid = self(),
-    RepairFun = 
-        fun(KL) -> 
-            lists:foreach(fun({{B, K}, _VCCompare}) -> 
-                                io:format("Delta found in ~w ~s~n", 
-                                            [B, binary_to_list(K)])
-                            end,
-                            KL) 
-        end,  
-    ReturnFun = fun(R) -> RPid ! {result, R} end,
-
-    % Exchange between empty vnodes
-    {ok, _P0, GUID0} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID0]),
-    {ExchangeState0, 0} = start_receiver(),
-    true = ExchangeState0 == root_compare,
-
-    % Same exchange - now using tree compare
-    GetBucketFun = 
-        fun(I) ->
-            case TupleBuckets of
-                true ->
-                    {?BUCKET_TYPE, integer_to_binary(I)};
-                false ->
-                    integer_to_binary(I)
-            end
-        end,
-    Bucket1 = GetBucketFun(1),
-    Bucket2 = GetBucketFun(2),
-    Bucket3 = GetBucketFun(3), 
-    Bucket4 = GetBucketFun(4),
-
-    {ok, _TC_P0, TC_GUID0} = 
-        aae_exchange:start(partial,
-                                [{exchange_vnodesendfun(VNN), IndexNs}],
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                RepairFun,
-                                ReturnFun,
-                                {filter, Bucket3, all, 
-                                    small, all, all, prehash}),
-    io:format("Exchange id for tree compare ~s~n", [TC_GUID0]),
-    {ExchangeStateTC0, 0} = start_receiver(),
-    true = ExchangeStateTC0 == tree_compare,
-    {ok, _TC_P1, TC_GUID1} = 
-        aae_exchange:start(partial,
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                [{exchange_vnodesendfun(VNN), IndexNs}],
-                                RepairFun,
-                                ReturnFun,
-                                {filter, Bucket3, all, 
-                                    small, all, all, prehash}),
-    io:format("Exchange id for tree compare ~s~n", [TC_GUID1]),
-    {ExchangeStateTC1, 0} = start_receiver(),
-    true = ExchangeStateTC1 == tree_compare,
-
-    ObjList = gen_riakobjects(InitialKeyCount, [], TupleBuckets),
-    ReplaceList = gen_riakobjects(100, [], TupleBuckets), 
-        % some objects to replace the first 100 objects
-    DeleteList1 = lists:sublist(ObjList, 200, 100),
-    DeleteList2 = 
-        lists:sublist(ObjList, 400, 10) ++ 
-        lists:sublist(ObjList, 500, 10) ++ 
-        lists:sublist(ObjList, 600, 10),
-
-    RehashList = lists:sublist(ObjList, 700, 10),
-
-    PutFun = 
-        fun(Store1, Store2) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                mock_kv_vnode:put(Store1, Object, PL, [Store2])
-            end
-        end,
-    DeleteFun =
-        fun(Stores) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                lists:foreach(
-                    fun(Store) -> 
-                        mock_kv_vnode:backend_delete(Store, 
-                                                        Object#r_object.bucket,
-                                                        Object#r_object.key,
-                                                        PL)
-                    end,
-                    Stores)
-            end
-        end,
-    RehashFun =
-        fun(Stores) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                lists:foreach(
-                    fun(Store) -> 
-                        mock_kv_vnode:rehash(Store, 
-                                                Object#r_object.bucket,
-                                                Object#r_object.key,
-                                                PL)
-                    end,
-                    Stores)
-            end
-        end,
-    
-    % Load objects into both stores
-    PutFun1 = PutFun(VNN, VNP),
-    PutFun2 = PutFun(VNP, VNN),
-    {OL1, OL2A} = lists:split(InitialKeyCount div 2, ObjList),
-    {[RogueObjC1, RogueObjC2], OL2} = lists:split(2, OL2A),
-        % Keep some rogue objects to cause failures, by not putting them
-        % correctly into both vnodes.  These aren't loaded yet
-    RogueObj1 = RogueObjC1#r_object{bucket = Bucket1},
-    RogueObj2 = RogueObjC2#r_object{bucket = Bucket2},
-    ok = lists:foreach(PutFun1, OL1),
-    ok = lists:foreach(PutFun2, OL2),
-    ok = lists:foreach(PutFun1, ReplaceList),
-    ok = lists:foreach(DeleteFun([VNN, VNP]), DeleteList1),
-    
-    % Exchange between equivalent vnodes
-    {ok, _P1, GUID1} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID1]),
-    {ExchangeState1, 0} = start_receiver(),
-    true = ExchangeState1 == root_compare,
-
-    % Rehash some entries and confirm root_compare still matches, as 
-    % rehash doesn't do anything
-    ok = lists:foreach(RehashFun([VNN, VNP]), RehashList),
-    {ok, _P1a, GUID1a} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID1a]),
-    {ExchangeState1a, 0} = start_receiver(),
-    true = ExchangeState1a == root_compare,
-
-    % Compare the two stores using an AAE fold - and prove that AAE fold is
-    % working as expected
-    Bucket = 
-        case TupleBuckets of
-            true ->
-                {?BUCKET_TYPE, integer_to_binary(3)};
-            false ->
-                 integer_to_binary(3)
-        end,
-    StartKey = list_to_binary(string:right(integer_to_list(10), 6, $0)),
-    EndKey = list_to_binary(string:right(integer_to_list(50), 6, $0)),
-    Elements = [{sibcount, null}, {clock, null}, {hash, null}],
-    InitAcc = {[], 0},
-    FoldKRFun = 
-        fun(FB, FK, FEs, {KCHAcc, SCAcc}) ->
-            true = FB == Bucket,
-            true = FK >= StartKey,
-            true = FK < EndKey,
-            {clock, FC} = lists:keyfind(clock, 1, FEs),
-            {hash, FH} = lists:keyfind(hash, 1, FEs),
-            {sibcount, FSC} = lists:keyfind(sibcount, 1, FEs),
-            {lists:usort([{FK, FC, FH}|KCHAcc]), SCAcc + FSC}
-        end,
-    
-    {async, VNNF} = 
-        mock_kv_vnode:fold_aae(VNN, 
-                                {key_range, Bucket, StartKey, EndKey},
-                                all,
-                                FoldKRFun, 
-                                InitAcc,
-                                Elements),
-    {async, VNPF} = 
-        mock_kv_vnode:fold_aae(VNP, 
-                                {key_range, Bucket, StartKey, EndKey},
-                                all,
-                                FoldKRFun, 
-                                InitAcc,
-                                Elements),
-    
-    {VNNF_KL, VNNF_SC} = VNNF(),
-    {VNPF_KL, VNPF_SC} = VNPF(),
-    true = VNNF_SC == 8,
-    true = VNPF_SC == 8,
-    true = lists:usort(VNNF_KL) == lists:usort(VNPF_KL),
-    true = length(VNNF_KL) == 8,
-    true = length(VNPF_KL) == 8,
-    
-    [{K1, C1, H1}|Rest] = VNNF_KL,
-    [{K2, C2, H2}|_Rest] = Rest,
-    BinaryKey1 = aae_util:make_binarykey(Bucket, K1),
-    BinaryKey2 = aae_util:make_binarykey(Bucket, K2),
-    SegmentID1 = 
-        leveled_tictac:get_segment(
-            element(1, leveled_tictac:tictac_hash(BinaryKey1, <<>>)), 
-            small),
-    SegmentID2 = 
-        leveled_tictac:get_segment(
-            element(1, leveled_tictac:tictac_hash(BinaryKey2, <<>>)), 
-            small),
-    io:format("Looking for Segment IDs K1 ~w ~w K2 ~w ~w~n",
-                [K1, SegmentID1, K2, SegmentID2]),
-
-    {async, VNNF_SL} = 
-        mock_kv_vnode:fold_aae(VNN, 
-                                {key_range, Bucket, StartKey, EndKey},
-                                {segments, [SegmentID1, SegmentID2], small},
-                                FoldKRFun, 
-                                InitAcc,
-                                Elements),
-    {async, VNPF_SL} = 
-        mock_kv_vnode:fold_aae(VNP, 
-                                {key_range, Bucket, StartKey, EndKey},
-                                {segments, [SegmentID1, SegmentID2], small},
-                                FoldKRFun, 
-                                InitAcc,
-                                Elements),
-    {[{K1, C1, H1}, {K2, C2, H2}], 2} = VNNF_SL(),
-    {[{K1, C1, H1}, {K2, C2, H2}], 2} = VNPF_SL(),
-
-    % Make change to one vnode only (the parallel one)
-    Idx1 = erlang:phash2(RogueObj1#r_object.key) rem length(IndexNs),
-    mock_kv_vnode:put(VNP, RogueObj1, lists:nth(Idx1 + 1, IndexNs), []),
-
-    % Exchange between nodes to expose difference
-    {ok, _P2, GUID2} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID2]),
-    {ExchangeState2, 1} = start_receiver(),
-    true = ExchangeState2 == clock_compare,
-
-    % Make change to one vnode only (the native one)
-    Idx2 = erlang:phash2(RogueObj2#r_object.key) rem length(IndexNs),
-    mock_kv_vnode:put(VNN, RogueObj2, lists:nth(Idx2 + 1, IndexNs), []),
-
-    % Exchange between nodes to expose differences (one in VNN, one in VNP)
-    {ok, _P3, GUID3} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
-                                [{exchange_vnodesendfun(VNP), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID3]),
-    {ExchangeState3, 2} = start_receiver(),
-    true = ExchangeState3 == clock_compare,
-
-    {RebuildN, false} = mock_kv_vnode:rebuild(VNN, false),
-    {RebuildP, false} = mock_kv_vnode:rebuild(VNP, false),
-    % Discover Next rebuild times - should be in the future as both stores
-    % were started empty, and hence without the need to rebuild
-    io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildN, RebuildP]),
-    true = RebuildN > os:timestamp(),
-    true = RebuildP > os:timestamp(),
-
-    ok = mock_kv_vnode:close(VNN),
-    ok = mock_kv_vnode:close(VNP),
-
-    % Restart the vnodes, confirm next rebuilds are still in the future 
-    % between startup and shutdown the next_rebuild will be rescheduled to
-    % a different time, as the look at the last rebuild time and schedule 
-    % forward from there.
-    {ok, VNNa} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
-    {ok, VNPa} = mock_kv_vnode:open(MockPathP, parallel, IndexNs, PreflistFun),
-    {RebuildNa, false} = mock_kv_vnode:rebuild(VNNa, false),
-    {RebuildPa, false} = mock_kv_vnode:rebuild(VNPa, false),
-    io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildNa, RebuildPa]),
-    true = RebuildNa > os:timestamp(),
-    true = RebuildPa > os:timestamp(),
-
-    % Exchange between nodes to expose differences (one in VNN, one in VNP)
-    % Should still discover the same difference as when they were closed.
-    {ok, _P3a, GUID3a} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
-                                [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID3a]),
-    {ExchangeState3a, 2} = start_receiver(),
-    true = ExchangeState3a == clock_compare,
-
-    % Prompts for a rebuild of both stores.  The rebuild is a rebuild of both
-    % the store and the tree in the case of the parallel vnode, and just the
-    % tree in the case of the native rebuild
-    {RebuildNb, true} = mock_kv_vnode:rebuild(VNNa, true),
-    
-    true = RebuildNb > os:timestamp(), 
-        % next rebuild was in the future, and is still scheduled as such
-        % key thing that the ongoing rebuild status is now true (the second 
-        % element of the rebuild response)
-
-    % Now poll to check to see when the rebuild is complete
-    wait_for_rebuild(VNNa),
-
-    % Next rebuild times should now still be in the future
-    {RebuildNc, false} = mock_kv_vnode:rebuild(VNNa, false),
-    {RebuildPc, false} = mock_kv_vnode:rebuild(VNPa, false),
-    true = RebuildPc == RebuildPa, % Should not have changed
-
-    % Following a completed rebuild - the exchange should still work as 
-    % before, spotting two differences
-    {ok, _P3b, GUID3b} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
-                                [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID3b]),
-    {ExchangeState3b, 2} = start_receiver(),
-    true = ExchangeState3b == clock_compare,
-
-    {RebuildPb, true} = mock_kv_vnode:rebuild(VNPa, true),
-    true = RebuildPb > os:timestamp(),
-
-    % There should now be a rebuild in progress - but immediately check that 
-    % an exchange will still work (spotting the same two differences as before
-    % following a clock_compare)
-    {ok, _P3c, GUID3c} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
-                                [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID3c]),
-    {ExchangeState3c, 2} = start_receiver(),
-    true = ExchangeState3c == clock_compare,
-
-    wait_for_rebuild(VNPa),
-    {RebuildNd, false} = mock_kv_vnode:rebuild(VNNa, false),
-    {RebuildPd, false} = mock_kv_vnode:rebuild(VNPa, false),
-    true = RebuildNd == RebuildNc,
-    true = RebuildPd > os:timestamp(),
-    
-    % Rebuild now complete - should get the same result for an exchange
-    {ok, _P3d, GUID3d} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
-                                [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID3d]),
-    {ExchangeState3d, 2} = start_receiver(),
-    true = ExchangeState3d == clock_compare,
-
-    % Delete some keys - and see the size of the delta increase
-    ok = lists:foreach(DeleteFun([VNPa]), DeleteList2),
-    {ok, _P4a, GUID4a} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
-                                [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID4a]),
-    {ExchangeState4a, 32} = start_receiver(),
-    true = ExchangeState4a == clock_compare,
-    % Balance the deletions
-    ok = lists:foreach(DeleteFun([VNNa]), DeleteList2),
-    {ok, _P4b, GUID4b} = 
-        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
-                                [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                RepairFun,
-                                ReturnFun),
-    io:format("Exchange id ~s~n", [GUID4b]),
-    {ExchangeState4b, 2} = start_receiver(),
-    true = ExchangeState4b == clock_compare,
-
-    % Same exchange - now using tree compare
-    CheckBucketList = [Bucket1, Bucket2],
-    CheckBucketFun = 
-        fun(CheckBucket, Acc) ->
-            CBFilters = {filter, CheckBucket, all, small, all, all, prehash},
-            {ok, _TCCB_P, TCCB_GUID} = 
-                aae_exchange:start(partial,
-                                    [{exchange_vnodesendfun(VNNa), IndexNs}],
-                                    [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                    RepairFun,
-                                    ReturnFun,
-                                    CBFilters),
-            io:format("Exchange id for tree compare ~s~n", [TCCB_GUID]),
-            {ExchangeStateTCCB, CBN} = start_receiver(),
-            true = ExchangeStateTCCB == clock_compare,
-            io:format("~w differences found in bucket ~w~n", 
-                        [CBN, CheckBucket]),
-            Acc + CBN
-        end,
-    true = 2 == lists:foldl(CheckBucketFun, 0, CheckBucketList),
-
-    %
-    %
-
-    true = InitialKeyCount > 2000,
-    RplObjListTC = gen_riakobjects(2000, [], TupleBuckets),
-    FilterBucket3Fun = fun(RObj) -> RObj#r_object.bucket == Bucket3 end,
-    FilterBucket4Fun = fun(RObj) -> RObj#r_object.bucket == Bucket4 end,
-    RplObjListTC3 = lists:filter(FilterBucket3Fun, RplObjListTC),
-        % Only have changes in Bucket 3
-    RplObjListTC4 = lists:filter(FilterBucket4Fun, RplObjListTC),
-        % Only have changes in Bucket 4
-
-    SingleSidedPutFun =
-        fun(MVN) ->
-            fun(RObj) ->
-                PL = PreflistFun(null, RObj#r_object.key),
-                mock_kv_vnode:put(MVN, RObj, PL, [])
-            end
-        end,
-    lists:foreach(SingleSidedPutFun(VNNa), RplObjListTC3),
-    lists:foreach(SingleSidedPutFun(VNPa), RplObjListTC4),
-
-    NoRepairCheckB3 = CheckBucketFun(Bucket3, 0),
-    NoRepairCheckB4 = CheckBucketFun(Bucket4, 0),
-    true = length(RplObjListTC3) > NoRepairCheckB3,
-    true = length(RplObjListTC4) > NoRepairCheckB4,
-        % this should be less than, as a subset of mismatched segments will
-        % be passed to fetch clocks
-    true = 0 < NoRepairCheckB3,
-    true = 0 < NoRepairCheckB4,
-       
-    RepairListMapFun = fun(RObj) -> {RObj#r_object.key, RObj} end,
-    RepairListTC3 = lists:map(RepairListMapFun, RplObjListTC3),
-    RepairListTC4 = lists:map(RepairListMapFun, RplObjListTC4),
-    GenuineRepairFun =
-        fun(SourceVnode, TargetVnode, RepairList) ->
-            fun(KL) -> 
-                SubRepairFun = 
-                    fun({{RepB, K}, _VCCompare}, Acc) -> 
-                        case lists:keyfind(K, 1, RepairList) of
-                            {K, RObj} ->
-                                PL = PreflistFun(null, K),
-                                ok = mock_kv_vnode:read_repair(SourceVnode,
-                                                                RObj,
-                                                                PL,
-                                                                [TargetVnode]),
-                                Acc + 1;
-                            false ->
-                                io:format("Missing from repair list ~w ~w~n",
-                                            [RepB, K]),
-                                Acc
-                        end
-                    end,
-                Repaired = lists:foldl(SubRepairFun, 0, KL),
-                io:format("~w keys repaired to vnode ~w~n",
-                    [Repaired, TargetVnode]) 
-            end
-        end,
-    RepairFunTC3 = GenuineRepairFun(VNNa, VNPa, RepairListTC3),
-    RepairFunTC4 = GenuineRepairFun(VNPa, VNNa, RepairListTC4),
-
-    RepairBucketFun = 
-        fun(CheckBucket, TargettedRepairFun, Hash) ->
-            CBFilters = {filter, CheckBucket, all, small, all, all, Hash},
-            {ok, _TCCB_P, TCCB_GUID} = 
-                aae_exchange:start(partial,
-                                    [{exchange_vnodesendfun(VNNa), IndexNs}],
-                                    [{exchange_vnodesendfun(VNPa), IndexNs}],
-                                    TargettedRepairFun,
-                                    ReturnFun,
-                                    CBFilters),
-            io:format("Exchange id for tree compare ~s~n", [TCCB_GUID]),
-            start_receiver()
-        end,
-    
-    FoldRepair3Fun = 
-        fun(_I, Acc) ->
-            case RepairBucketFun(Bucket3, RepairFunTC3, prehash) of
-                {clock_compare, Count3} ->
-                    Acc + Count3;
-                {tree_compare, 0} ->
-                    Acc
-            end
-        end,
-    TotalRepairs3 = lists:foldl(FoldRepair3Fun, 0, lists:seq(1, 6)),
-    io:format("Repaired ~w from list of length ~w~n",
-                [TotalRepairs3, length(RepairListTC3)]),
-    true = length(RepairListTC3) =< TotalRepairs3,
-
-    FoldRepair4Fun = 
-        fun(_I, Acc) ->
-            case RepairBucketFun(Bucket4, RepairFunTC4, {rehash, 5000}) of
-                {clock_compare, Count4} ->
-                    Acc + Count4;
-                {tree_compare, 0} ->
-                    Acc
-            end
-        end,
-    TotalRepairs4 = lists:foldl(FoldRepair4Fun, 0, lists:seq(1, 6)),
-    io:format("Repaired ~w from list of length ~w~n",
-                [TotalRepairs4, length(RepairListTC4)]),
-    true = length(RepairListTC4) =< TotalRepairs4,
-
-    % Shutdown and clear down files
-    ok = mock_kv_vnode:close(VNNa),
-    ok = mock_kv_vnode:close(VNPa),
-    RootPath = reset_filestructure().
-
-
-wait_for_rebuild(Vnode) ->
-    RebuildComplete = 
-        lists:foldl(fun(Wait, Complete) ->
-                            case Complete of 
-                                true ->
-                                    true;
-                                false ->
-                                    timer:sleep(Wait),
-                                    {_TSN, RSN} = 
-                                        mock_kv_vnode:rebuild(Vnode, false),
-                                    % Waiting for rebuild status to be false 
-                                    % on both vnodes, which would indicate
-                                    % that both rebuilds have completed
-                                    (not RSN)
-                            end
-                        end,
-                        false,
-                        [1000, 2000, 3000, 5000, 8000, 13000, 21000]),
-    
-    % Both rebuilds have completed
-    true = RebuildComplete == true.
-
-
-mock_vnode_coveragefold_nativemedium(_Config) ->
-    mock_vnode_coveragefolder(native, 50000, true).
-
-mock_vnode_coveragefold_nativesmall(_Config) ->
-    mock_vnode_coveragefolder(native, 5000, false).
-
-mock_vnode_coveragefold_parallelsmall(_Config) ->
-    mock_vnode_coveragefolder(parallel, 5000, true).
-
-mock_vnode_coveragefold_parallelmedium(_Config) ->
-    mock_vnode_coveragefolder(parallel, 50000, false).
-
-
-
-mock_vnode_coveragefolder(Type, InitialKeyCount, TupleBuckets) ->
-    % This should load a set of 4 vnodes, with the data partitioned across the
-    % vnodes n=2 to provide for 2 different coverage plans.
-    %
-    % After the load, an exchange can confirm consistency between the coverage 
-    % plans.  Then run some folds to make sure that the folds produce the 
-    % expected results 
-    RootPath = reset_filestructure(),
-    MockPathN1 = filename:join(RootPath, "mock_native1/"),
-    MockPathN2 = filename:join(RootPath, "mock_native2/"),
-    MockPathN3 = filename:join(RootPath, "mock_native3/"),
-    MockPathN4 = filename:join(RootPath, "mock_native4/"),
-    
-    IndexNs = 
-        [{1, 2}, {2, 2}, {3, 2}, {0, 2}],
-    PreflistFun = 
-        fun(_B, K) ->
-            Idx = erlang:phash2(K) rem length(IndexNs),
-            lists:nth(Idx + 1, IndexNs)
-        end,
-
-    % Open four vnodes to take two of the rpeflists each
-    % - this isintended to replicate a ring-size=4, n-val=2 ring 
-    {ok, VNN1} = 
-        mock_kv_vnode:open(MockPathN1, Type, [{1, 2}, {0, 2}], PreflistFun),
-    {ok, VNN2} = 
-        mock_kv_vnode:open(MockPathN2, Type, [{2, 2}, {1, 2}], PreflistFun),
-    {ok, VNN3} = 
-        mock_kv_vnode:open(MockPathN3, Type, [{3, 2}, {2, 2}], PreflistFun),
-    {ok, VNN4} = 
-        mock_kv_vnode:open(MockPathN4, Type, [{0, 2}, {3, 2}], PreflistFun),
-
-    % Mapping of preflists to [Primary, Secondary] vnodes
-    RingN =
-        [{{1, 2}, [VNN1, VNN2]}, {{2, 2}, [VNN2, VNN3]}, 
-            {{3, 2}, [VNN3, VNN4]}, {{0, 2}, [VNN4, VNN1]}],
-
-    % Add each key to the vnode at the head of the preflist, and then push the
-    % change to the one at the tail.  
-    PutFun = 
-        fun(Ring) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                {PL, [Primary, Secondary]} = lists:keyfind(PL, 1, Ring),
-                mock_kv_vnode:put(Primary, Object, PL, [Secondary])
-            end
-        end,
-
-    ObjList = gen_riakobjects(InitialKeyCount, [], TupleBuckets),
-    ok = lists:foreach(PutFun(RingN), ObjList),
-
-    % Provide two coverage plans, equivalent to normal ring coverage plans
-    % with offset=0 and offset=1
-    AllPrimariesMap =
-        fun({IndexN, [Pri, _FB]}) ->
-            {exchange_vnodesendfun(Pri), [IndexN]}
-        end,
-    AllSecondariesMap =
-        fun({IndexN, [_Pri, FB]}) ->
-            {exchange_vnodesendfun(FB), [IndexN]}
-        end,
-    AllPrimaries = lists:map(AllPrimariesMap, RingN),
-    AllSecondaries = lists:map(AllSecondariesMap, RingN),
-
-    RPid = self(),
-    RepairFun = fun(_KL) -> null end,  
-    ReturnFun = fun(R) -> RPid ! {result, R} end,
-
-    {ok, _P1, GUID1} = 
-        aae_exchange:start(AllPrimaries, AllSecondaries, RepairFun, ReturnFun),
-    io:format("Exchange id ~s~n", [GUID1]),
-    {ExchangeState1, 0} = start_receiver(),
-    true = ExchangeState1 == root_compare,
-
-
-    % Fold over a valid coverage plan to find siblings (there are none) 
-    SibCountFoldFun =
-        fun(B, K, V, {NoSibAcc, SibAcc}) ->
-            {sibcount, SC} = lists:keyfind(sibcount, 1, V),
-            case SC of 
-                1 -> {NoSibAcc + 1, SibAcc};
-                _ -> {NoSibAcc, [{B, K}|SibAcc]}
-            end
-        end,
-    
-    SWF1 = os:timestamp(),
-    {async, Folder1} = 
-        mock_kv_vnode:fold_aae(VNN1, all, all, SibCountFoldFun, 
-                                {0, []}, [{sibcount, null}]),
-    {async, Folder3} = 
-        mock_kv_vnode:fold_aae(VNN3, all, all, SibCountFoldFun, 
-                                Folder1(), [{sibcount, null}]),
-    {SC1, SibL1} = Folder3(),
-    io:format("Coverage fold took ~w with output ~w for store ~w~n", 
-                [timer:now_diff(os:timestamp(), SWF1),SC1, Type]),
-    true = SC1 == InitialKeyCount,
-    true = [] == SibL1,
-
-    SWF2 = os:timestamp(),
-    BucketListA = 
-        case TupleBuckets of
-            true ->
-                [{?BUCKET_TYPE, integer_to_binary(0)},
-                    {?BUCKET_TYPE, integer_to_binary(1)}];
-            false ->
-                [integer_to_binary(0), integer_to_binary(1)]
-        end,
-    {async, Folder2} = 
-        mock_kv_vnode:fold_aae(VNN2, 
-                                {buckets, BucketListA}, all, 
-                                SibCountFoldFun, {0, []},
-                                [{sibcount, null}]),
-    {async, Folder4} = 
-        mock_kv_vnode:fold_aae(VNN4, 
-                                {buckets, BucketListA}, all,
-                                SibCountFoldFun, Folder2(),
-                                [{sibcount, null}]),
-    {SC2, SibL2} = Folder4(),
-    io:format("Coverage fold took ~w with output ~w for store ~w~n", 
-                [timer:now_diff(os:timestamp(), SWF2),SC2, Type]),
-    true = SC2 == 2 * (InitialKeyCount div 5),
-    true = [] == SibL2,
-
-    % A fold over two coverage plans to compare the list of {B, K, H, Sz} 
-    % tuples found within the coverage plans
-    HashSizeFoldFun =
-        fun(B, K, V, Acc) ->
-            {hash, H} = lists:keyfind(hash, 1, V),
-            {size, Sz} = lists:keyfind(size, 1, V),
-            [{B, K, H, Sz}|Acc]
-        end,
-
-    {async, Folder1HS} = 
-        mock_kv_vnode:fold_aae(VNN1, all, all, HashSizeFoldFun, 
-                                [], [{hash, null}, {size, null}]),
-    {async, Folder3HS} = 
-        mock_kv_vnode:fold_aae(VNN3, all, all, HashSizeFoldFun, 
-                                Folder1HS(), [{hash, null}, {size, null}]),
-    BKHSzL1 = Folder3HS(),
-    true = length(BKHSzL1) == InitialKeyCount,
-
-    {async, Folder2HS} = 
-        mock_kv_vnode:fold_aae(VNN2, all, all, HashSizeFoldFun, 
-                                [], [{hash, null}, {size, null}]),
-    {async, Folder4HS} = 
-        mock_kv_vnode:fold_aae(VNN4, all, all, HashSizeFoldFun, 
-                                Folder2HS(), [{hash, null}, {size, null}]),
-    BKHSzL2 = Folder4HS(),
-    true = length(BKHSzL2) == InitialKeyCount,
-
-    true = lists:usort(BKHSzL2) == lists:usort(BKHSzL1),
-
-    ok = mock_kv_vnode:close(VNN1),
-    ok = mock_kv_vnode:close(VNN2),
-    ok = mock_kv_vnode:close(VNN3),
-    ok = mock_kv_vnode:close(VNN4),
-    RootPath = reset_filestructure().
-
-
-
-
-reset_filestructure() ->
-    reset_filestructure(0, ?ROOT_PATH).
-    
-reset_filestructure(Wait, RootPath) ->
-    io:format("Waiting ~w ms to give a chance for all file closes " ++
-                 "to complete~n", [Wait]),
-    timer:sleep(Wait),
-    clear_all(RootPath),
-    RootPath.
-
-clear_all(RootPath) ->
-    ok = filelib:ensure_dir(RootPath),
-    {ok, FNs} = file:list_dir(RootPath),
-    FoldFun =
-        fun(FN) ->
-            FFP = filename:join(RootPath, FN),
-            case filelib:is_dir(FFP) of 
-                true ->
-                    clear_all(FFP ++ "/");
-                false ->
-                    case filelib:is_file(FFP) of 
-                        true ->
-                            file:delete(FFP);
-                        false ->
-                            ok 
-                    end
-            end
-        end,
-    lists:foreach(FoldFun, FNs).
-
-
-gen_keys(KeyList, Count) ->
-    gen_keys(KeyList, Count, 0).
-
-gen_keys(KeyList, Count, Floor) when Count == Floor ->
-    KeyList;
-gen_keys(KeyList, Count, Floor) ->
-    Bucket = integer_to_binary(Count rem 5),  
-    Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
-    VersionVector = add_randomincrement([]),
-    gen_keys([{Bucket, Key, VersionVector}|KeyList], 
-                Count - 1,
-                Floor).
-
-put_keys(Cntrl, NVal, KL) ->
-    put_keys(Cntrl, NVal, KL, none).
-
-put_keys(_Cntrl, _Nval, [], _PrevVV) ->
-    ok;
-put_keys(Cntrl, Nval, [{Bucket, Key, VersionVector}|Tail], PrevVV) ->
-    ok = aae_controller:aae_put(Cntrl, 
-                                calc_preflist(Key, Nval), 
-                                Bucket, 
-                                Key, 
-                                VersionVector, 
-                                PrevVV, 
-                                {[os:timestamp()],
-                                    term_to_binary([{clock, VersionVector}])}),
-    put_keys(Cntrl, Nval, Tail, PrevVV).
-
-remove_keys(_Cntrl, _Nval, []) ->
-    ok;
-remove_keys(Cntrl, Nval, [{Bucket, Key, _VV}|Tail]) ->
-    ok = aae_controller:aae_put(Cntrl, 
-                                calc_preflist(Key, Nval), 
-                                Bucket, 
-                                Key, 
-                                none, 
-                                undefined, 
-                                <<>>),
-    remove_keys(Cntrl, Nval, Tail).
-
-
-gen_riakobjects(0, ObjectList, _TupleBuckets) ->
-    ObjectList;
-gen_riakobjects(Count, ObjectList, TupleBuckets) ->
-    Bucket = 
-        case TupleBuckets of
-            true ->
-                {?BUCKET_TYPE, integer_to_binary(Count rem 5)};
-            false ->
-                integer_to_binary(Count rem 5)
-        end,
-    Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
-    Value = leveled_rand:rand_bytes(512),
-    Obj = #r_object{bucket = Bucket,
-                    key = Key,
-                    contents = [#r_content{value = Value}]},
-    gen_riakobjects(Count - 1, [Obj|ObjectList], TupleBuckets).
+    RootPath = testutil:reset_filestructure().
 
 
 initial_load(InitialKeyCount, Cntrl1, Cntrl2) ->
 
     SW0 = os:timestamp(),
 
-    BKVListXS = gen_keys([], InitialKeyCount),
+    BKVListXS = testutil:gen_keys([], InitialKeyCount),
     {BKVList, _Discard} = lists:split(20, BKVListXS),
         % The first 20 keys discarded to create an overlap between the add
         % replace list
-    ok = put_keys(Cntrl1, 2, BKVList, none),
-    ok = put_keys(Cntrl2, 3, lists:reverse(BKVList), none),
+    ok = testutil:put_keys(Cntrl1, 2, BKVList, none),
+    ok = testutil:put_keys(Cntrl2, 3, lists:reverse(BKVList), none),
 
     {BKVListRem, _Ignore} = lists:split(10, BKVList),
-    ok = remove_keys(Cntrl1, 2, BKVListRem),
-    ok = remove_keys(Cntrl2, 3, BKVListRem),
+    ok = testutil:remove_keys(Cntrl1, 2, BKVListRem),
+    ok = testutil:remove_keys(Cntrl2, 3, BKVListRem),
 
     % Change all of the keys - cheat by using undefined rather than replace 
     % properly
 
-    BKVListR = gen_keys([], 100),
+    BKVListR = testutil:gen_keys([], 100),
         % As 100 > 20 expect 20 of these keys to be new, so no clock will be
         % returned from fetch_clock, and 80 of these will be updates
-    ok = put_keys(Cntrl1, 2, BKVListR, undefined),
-    ok = put_keys(Cntrl2, 3, BKVListR, undefined),
+    ok = testutil:put_keys(Cntrl1, 2, BKVListR, undefined),
+    ok = testutil:put_keys(Cntrl2, 3, BKVListR, undefined),
     
     io:format("Initial put complete in ~w ms~n", 
                 [timer:now_diff(os:timestamp(), SW0)/1000]).
@@ -1291,112 +273,22 @@ initial_load(InitialKeyCount, Cntrl1, Cntrl2) ->
 
 create_discrepancy(Cntrl, InitialKeyCount) ->
     % Create a discrepancy and discover it through exchange
-    BKVListN = gen_keys([], InitialKeyCount + 10, InitialKeyCount),
+    BKVListN = testutil:gen_keys([], InitialKeyCount + 10, InitialKeyCount),
     _SL = lists:foldl(fun({B, K, _V}, Acc) -> 
                             BK = aae_util:make_binarykey(B, K),
                             Seg = leveled_tictac:keyto_segment48(BK),
                             Seg0 = aae_keystore:generate_treesegment(Seg),
                             io:format("Generate new key B ~w K ~w " ++ 
-                                        "for Segment ~w ~w ~w partition ~w ~w~n",
-                                        [B, K, Seg0,  Seg0 bsr 8, Seg0 band 255, 
-                                        calc_preflist(K, 2), calc_preflist(K, 3)]),
+                                    "for Segment ~w ~w ~w partition ~w ~w~n",
+                                    [B, K, Seg0,  Seg0 bsr 8, Seg0 band 255, 
+                                        testutil:calc_preflist(K, 2), 
+                                        testutil:calc_preflist(K, 3)]),
                             [Seg0|Acc]
                         end,
                         [],
                         BKVListN),
-    ok = put_keys(Cntrl, 2, BKVListN),
+    ok = testutil:put_keys(Cntrl, 2, BKVListN),
     BKVListN.
 
-add_randomincrement(Clock) ->
-    RandIncr = leveled_rand:uniform(100),
-    RandNode = lists:nth(leveled_rand:uniform(9), 
-                            ["a", "b", "c", "d", "e", "f", "g", "h", "i"]),
-    UpdClock = 
-        case lists:keytake(RandNode, 1, Clock) of 
-            false ->
-                [{RandNode, RandIncr}|Clock];
-            {value, {RandNode, Incr0}, Rest} ->
-                [{RandNode, Incr0 + RandIncr}|Rest]
-        end,
-    lists:usort(UpdClock).
 
-calc_preflist(Key, 2) ->
-    case erlang:phash2(Key) band 3 of 
-        0 ->
-            {2, 0};
-        _ ->
-            {2, 1}
-    end;
-calc_preflist(Key, 3) ->
-    case erlang:phash2(Key) band 3 of 
-        0 ->
-            {3, 0};
-        1 ->
-            {3, 1};
-        _ ->
-            {3, 2}
-    end.
-
-start_receiver() ->
-    receive
-        {result, Reply} ->
-            Reply 
-    end.
-
-
-exchange_sendfun(Cntrl) ->
-    SendFun = 
-        fun(Msg, Preflists, Colour) ->
-            RPid = self(),
-            ReturnFun = 
-                fun(R) -> 
-                    io:format("Preparing reply to ~w for msg ~w colour ~w~n", 
-                                [RPid, Msg, Colour]),
-                    aae_exchange:reply(RPid, R, Colour)
-                end,
-            case Msg of 
-                fetch_root ->
-                    aae_controller:aae_mergeroot(Cntrl, 
-                                                    Preflists, 
-                                                    ReturnFun);
-                {fetch_branches, BranchIDs} ->
-                    aae_controller:aae_mergebranches(Cntrl, 
-                                                        Preflists, 
-                                                        BranchIDs, 
-                                                        ReturnFun);
-                {fetch_clocks, SegmentIDs} ->
-                    aae_controller:aae_fetchclocks(Cntrl,
-                                                        Preflists,
-                                                        SegmentIDs,
-                                                        ReturnFun,
-                                                        null)
-            end
-        end,
-    SendFun.
-
-exchange_vnodesendfun(VN) ->
-    fun(Msg, Preflists, Colour) ->
-        RPid = self(),
-        ReturnFun = 
-            fun(R) -> 
-                io:format("Preparing reply to ~w for msg ~w colour ~w~n", 
-                            [RPid, Msg, Colour]),
-                aae_exchange:reply(RPid, R, Colour)
-            end,
-        mock_kv_vnode:exchange_message(VN, Msg, Preflists, ReturnFun)
-    end.
-
-
-repair_fun(SourceList, Cntrl, NVal) ->
-    Lookup = lists:map(fun({B, K, V}) -> {{B, K}, V} end, SourceList),
-    RepairFun = 
-        fun(BucketKeyL) ->
-            FoldFun =
-                fun({{B0, K0}, _VCDelta}, Acc) -> 
-                    {{B0, K0}, V0} = lists:keyfind({B0, K0}, 1, Lookup),
-                    [{B0, K0, V0}|Acc]
-                end,
-            KVL = lists:foldl(FoldFun, [], BucketKeyL),
-            ok = put_keys(Cntrl, NVal, KVL)
-        end,
-    RepairFun.
+exchange_sendfun(Cntrl) -> testutil:exchange_sendfun(Cntrl).

--- a/test/end_to_end/fold_SUITE.erl
+++ b/test/end_to_end/fold_SUITE.erl
@@ -1,0 +1,184 @@
+-module(fold_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-export([all/0]).
+-export([
+            aae_fold_keyorder/1,
+            aae_fold_segmentorder/1]).
+
+all() -> [
+            aae_fold_keyorder,
+            aae_fold_segmentorder
+        ].
+
+
+aae_fold_keyorder(_Config) ->
+    aae_fold_tester(leveled_ko, 50000).
+
+aae_fold_segmentorder(_Config) ->
+    aae_fold_tester(leveled_so, 50000).
+
+
+aae_fold_tester(ParallelStoreType, KeyCount) ->
+    RootPath = testutil:reset_filestructure(),
+    FoldPath1 = filename:join(RootPath, "folder1/"),
+    SplitF = 
+        fun(X) -> 
+            {leveled_rand:uniform(1000), 1, 0, element(1, X), element(2, X)}
+        end,
+    
+    {ok, Cntrl1} = 
+        aae_controller:aae_start({parallel, ParallelStoreType}, 
+                                    true, 
+                                    {1, 300}, 
+                                    [{2, 0}, {2, 1}], 
+                                    FoldPath1, 
+                                    SplitF),
+
+    BKVListXS = testutil:gen_keys([], KeyCount),
+    
+    {SWLowMegaS, SWLowS, _SWLowMicroS} = os:timestamp(),
+    timer:sleep(1000),
+    ok = testutil:put_keys(Cntrl1, 2, BKVListXS, none),
+    timer:sleep(1000),
+    {SWHighMegaS, SWHighS, _SWHighMicroS} = os:timestamp(),
+    BucketList = [integer_to_binary(1), integer_to_binary(3)],
+    FoldElements = [{clock, null}, {md, null}],
+    FoldFun =
+        fun(B, _K, ElementList, {B1Count, B3Count}) ->
+            {clock, FoldClock} = lists:keyfind(clock, 1, ElementList),
+            {md, FoldMD} = lists:keyfind(md, 1, ElementList),
+            case binary_to_term(FoldMD) of
+                [{clock, FoldClock}] ->
+                    case B of
+                        <<"1">> ->
+                            {B1Count + 1, B3Count};
+                        <<"3">> ->
+                            {B1Count, B3Count + 1}
+                    end
+            end
+        end,
+    InitAcc = {0, 0},
+    {async, Runner1} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                all,
+                                all,
+                                false,
+                                FoldFun,
+                                InitAcc,
+                                FoldElements),
+    true = {KeyCount div 5, KeyCount div 5} == Runner1(),
+
+    {async, Runner2} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                all,
+                                {SWLowMegaS * 1000000 + SWLowS,
+                                    SWHighMegaS * 1000000 + SWHighS},
+                                false,
+                                FoldFun,
+                                InitAcc,
+                                FoldElements),
+    true = {KeyCount div 5, KeyCount div 5} == Runner2(),
+
+    {async, Runner3} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                all,
+                                {0, SWLowMegaS * 1000000 + SWLowS},
+                                false,
+                                FoldFun,
+                                InitAcc,
+                                FoldElements),
+    
+    {0, 0} = Runner3(),
+
+    {async, Runner4} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                all,
+                                {SWHighMegaS * 1000000 + SWHighS, 
+                                    infinity},
+                                false,
+                                FoldFun,
+                                InitAcc,
+                                FoldElements),
+    {0, 0} = Runner4(),
+    
+    {async, Runner5} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                all,
+                                all,
+                                2000,
+                                FoldFun,
+                                InitAcc,
+                                FoldElements),
+    case ParallelStoreType of
+        leveled_ko ->
+            {0, {2000, 0}} = Runner5();
+        leveled_so ->
+            true = 
+                {-1, {KeyCount div 5, KeyCount div 5}} == Runner5()
+    end,
+
+    {async, Runner6} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                all,
+                                {SWLowMegaS * 1000000 + SWLowS,
+                                    SWHighMegaS * 1000000 + SWHighS},
+                                2000,
+                                FoldFun,
+                                InitAcc,
+                                FoldElements),
+    case ParallelStoreType of
+        leveled_ko ->
+            {0, {2000, 0}} = Runner6();
+        leveled_so ->
+            true = 
+                {-1, {KeyCount div 5, KeyCount div 5}} == Runner6()
+    end,
+
+    BKVSL = lists:sublist(BKVListXS, KeyCount - 1000, 128),
+    SegMapFun =
+        fun ({B, K, _VV}) ->
+            BinK = aae_util:make_binarykey(B, K),
+            Seg32 = leveled_tictac:keyto_segment32(BinK),
+            leveled_tictac:get_segment(Seg32, small)
+        end,
+    SegList = lists:map(SegMapFun, BKVSL),
+    BKVSL_ByBL =
+        lists:filter(fun({B, _K, _V}) -> lists:member(B, BucketList) end,
+                        BKVSL),
+    FoldClocksElements = [{clock, null}],
+    FoldClocksFun =
+        fun(B, K, ElementList, Acc) ->
+            {clock, FoldClock} = lists:keyfind(clock, 1, ElementList),
+            [{B, K, FoldClock}|Acc]
+        end,
+
+    {async, Runner7} = 
+        aae_controller:aae_fold(Cntrl1, 
+                                {buckets, BucketList},
+                                {segments, SegList, small},
+                                all,
+                                false,
+                                FoldClocksFun,
+                                [],
+                                FoldClocksElements),
+    
+    FetchedClocks = Runner7(),
+    io:format("Fetched ~w clocks with segment filter~n",
+                [length(FetchedClocks)]),
+    true = 
+        [] == lists:subtract(BKVSL_ByBL, FetchedClocks),
+        % Found all the Keys and clocks in the list
+    true =
+        (KeyCount div 64) > length(lists:subtract(FetchedClocks, BKVSL_ByBL)),
+        % Didn't find "too many" others due to collisions on segment
+
+    ok = aae_controller:aae_close(Cntrl1),
+    RootPath = testutil:reset_filestructure().
+
+

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -57,6 +57,7 @@
                 aae_controller :: pid(),
                 vnode_store :: pid(),
                 vnode_id :: binary(),
+                aae_type :: parallel|native,
                 vnode_sqn = 1 :: integer(),
                 preflist_fun = null :: preflist_fun(),
                 aae_rebuild = false :: boolean()}).
@@ -191,6 +192,7 @@ init([Opts]) ->
                                     RP, 
                                     fun from_aae_binary/1),
     {ok, #state{root_path = RP,
+                aae_type = KeyStoreType,
                 vnode_store = VnSt,
                 index_ns = Opts#options.index_ns,
                 aae_controller = AAECntrl,

--- a/test/end_to_end/mockvnode_SUITE.erl
+++ b/test/end_to_end/mockvnode_SUITE.erl
@@ -534,8 +534,7 @@ mock_vnode_loadexchangeandrebuild_tester(TupleBuckets) ->
     TotalRepairs3 = lists:foldl(FoldRepair3Fun, 0, lists:seq(1, 6)),
     io:format("Repaired ~w from list of length ~w~n",
                 [TotalRepairs3, length(RepairListTC3)]),
-    true = length(RepairListTC3) =< TotalRepairs3,
-    % **
+    true = length(RepairListTC3) == TotalRepairs3,
 
     FoldRepair4Fun = 
         fun(_I, Acc) ->
@@ -549,11 +548,7 @@ mock_vnode_loadexchangeandrebuild_tester(TupleBuckets) ->
     TotalRepairs4 = lists:foldl(FoldRepair4Fun, 0, lists:seq(1, 6)),
     io:format("Repaired ~w from list of length ~w~n",
                 [TotalRepairs4, length(RepairListTC4)]),
-    true = length(RepairListTC4) =< TotalRepairs4,
-    % **
-    % ** - note the use of "=<" here ..appears to eb sometimes out by one
-    % - timing issues?
-    % TODO: Clarify as to why, and is it sometimes more than 1s
+    true = length(RepairListTC4) == TotalRepairs4,
 
     % Check with a key range.  Testing with a modified range requires more
     % effort as the objects don't have a last modified date

--- a/test/end_to_end/mockvnode_SUITE.erl
+++ b/test/end_to_end/mockvnode_SUITE.erl
@@ -1,0 +1,796 @@
+-module(mockvnode_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-export([all/0]).
+-export([mock_vnode_coveragefold_nativemedium/1,
+            mock_vnode_coveragefold_nativesmall/1,
+            mock_vnode_coveragefold_parallelmedium/1,
+            mock_vnode_coveragefold_parallelsmall/1,
+            mock_vnode_loadexchangeandrebuild_stbucket/1,
+            mock_vnode_loadexchangeandrebuild_tuplebucket/1]).
+
+all() -> [
+            mock_vnode_coveragefold_nativemedium,
+            mock_vnode_coveragefold_nativesmall,
+            mock_vnode_coveragefold_parallelmedium,
+            mock_vnode_coveragefold_parallelsmall,
+            mock_vnode_loadexchangeandrebuild_stbucket,
+            mock_vnode_loadexchangeandrebuild_tuplebucket
+        ].
+
+
+-include("testutil.hrl").
+
+
+mock_vnode_loadexchangeandrebuild_stbucket(_Config) ->
+    mock_vnode_loadexchangeandrebuild_tester(false).
+
+mock_vnode_loadexchangeandrebuild_tuplebucket(_Config) ->
+    mock_vnode_loadexchangeandrebuild_tester(true).
+
+mock_vnode_loadexchangeandrebuild_tester(TupleBuckets) ->
+    % Load up two vnodes with same data, with the data in each node split 
+    % across 3 partitions (n=1).
+    %
+    % The purpose if to perform exchanges to first highlight no differences, 
+    % and then once a difference is created, discover any difference 
+    _TestStartPoint = os:timestamp(),
+    InitialKeyCount = 50000,
+    RootPath = testutil:reset_filestructure(),
+    MockPathN = filename:join(RootPath, "mock_native/"),
+    MockPathP = filename:join(RootPath, "mock_parallel/"),
+
+    IndexNs = [{1, 3}, {2, 3}, {3, 3}],
+    PreflistFun = 
+        fun(_B, K) ->
+            Idx = erlang:phash2(K) rem length(IndexNs),
+            lists:nth(Idx + 1, IndexNs)
+        end,
+
+    % Start up to two mock vnodes
+    % - VNN is a native vnode (where the AAE process will not keep a parallel
+    % key store)
+    % - VNP is a parallel vnode (where a separate AAE key store is required 
+    % to be kept in parallel)
+    {ok, VNN} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
+    {ok, VNP} = mock_kv_vnode:open(MockPathP, parallel, IndexNs, PreflistFun),
+
+    RPid = self(),
+    LogNotRepairFun = 
+        fun(KL) -> 
+            lists:foreach(fun({{B, K}, VCCompare}) -> 
+                                io:format("Delta found in ~w ~s ~w~n",
+                                            [B,
+                                                binary_to_list(K),
+                                                VCCompare])
+                            end,
+                            KL) 
+        end,
+    NullRepairFun = fun(_KL) -> ok end, 
+    ReturnFun = fun(R) -> RPid ! {result, R} end,
+
+    % Exchange between empty vnodes
+    {ok, _P0, GUID0} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                LogNotRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID0]),
+    {ExchangeState0, 0} = testutil:start_receiver(),
+    true = ExchangeState0 == root_compare,
+
+    % Same exchange - now using tree compare
+    GetBucketFun = 
+        fun(I) ->
+            case TupleBuckets of
+                true ->
+                    {?BUCKET_TYPE, integer_to_binary(I)};
+                false ->
+                    integer_to_binary(I)
+            end
+        end,
+    Bucket1 = GetBucketFun(1),
+    Bucket2 = GetBucketFun(2),
+    Bucket3 = GetBucketFun(3), 
+    Bucket4 = GetBucketFun(4),
+
+    {ok, _TC_P0, TC_GUID0} = 
+        aae_exchange:start(partial,
+                                [{exchange_vnodesendfun(VNN), IndexNs}],
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                LogNotRepairFun,
+                                ReturnFun,
+                                {filter, Bucket3, all, 
+                                    small, all, all, prehash}),
+    io:format("Exchange id for tree compare ~s~n", [TC_GUID0]),
+    {ExchangeStateTC0, 0} = testutil:start_receiver(),
+    true = ExchangeStateTC0 == tree_compare,
+    {ok, _TC_P1, TC_GUID1} = 
+        aae_exchange:start(partial,
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                [{exchange_vnodesendfun(VNN), IndexNs}],
+                                LogNotRepairFun,
+                                ReturnFun,
+                                {filter, Bucket3, all, 
+                                    small, all, all, prehash}),
+    io:format("Exchange id for tree compare ~s~n", [TC_GUID1]),
+    {ExchangeStateTC1, 0} = testutil:start_receiver(),
+    true = ExchangeStateTC1 == tree_compare,
+
+    ObjList = testutil:gen_riakobjects(InitialKeyCount, [], TupleBuckets),
+    ReplaceList = testutil:gen_riakobjects(100, [], TupleBuckets), 
+        % some objects to replace the first 100 objects
+    DeleteList1 = lists:sublist(ObjList, 200, 100),
+    DeleteList2 = 
+        lists:sublist(ObjList, 400, 10) ++ 
+        lists:sublist(ObjList, 500, 10) ++ 
+        lists:sublist(ObjList, 600, 10),
+
+    RehashList = lists:sublist(ObjList, 700, 10),
+
+    PutFun = 
+        fun(Store1, Store2) ->
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                mock_kv_vnode:put(Store1, Object, PL, [Store2])
+            end
+        end,
+    DeleteFun =
+        fun(Stores) ->
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                lists:foreach(
+                    fun(Store) -> 
+                        mock_kv_vnode:backend_delete(Store, 
+                                                        Object#r_object.bucket,
+                                                        Object#r_object.key,
+                                                        PL)
+                    end,
+                    Stores)
+            end
+        end,
+    RehashFun =
+        fun(Stores) ->
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                lists:foreach(
+                    fun(Store) -> 
+                        mock_kv_vnode:rehash(Store, 
+                                                Object#r_object.bucket,
+                                                Object#r_object.key,
+                                                PL)
+                    end,
+                    Stores)
+            end
+        end,
+    
+    % Load objects into both stores
+    PutFun1 = PutFun(VNN, VNP),
+    PutFun2 = PutFun(VNP, VNN),
+    {OL1, OL2A} = lists:split(InitialKeyCount div 2, ObjList),
+    {[RogueObjC1, RogueObjC2], OL2} = lists:split(2, OL2A),
+        % Keep some rogue objects to cause failures, by not putting them
+        % correctly into both vnodes.  These aren't loaded yet
+    RogueObj1 = RogueObjC1#r_object{bucket = Bucket1},
+    RogueObj2 = RogueObjC2#r_object{bucket = Bucket2},
+    ok = lists:foreach(PutFun1, OL1),
+    ok = lists:foreach(PutFun2, OL2),
+    ok = lists:foreach(PutFun1, ReplaceList),
+    ok = lists:foreach(DeleteFun([VNN, VNP]), DeleteList1),
+    
+    % Exchange between equivalent vnodes
+    {ok, _P1, GUID1} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                LogNotRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID1]),
+    {ExchangeState1, 0} = testutil:start_receiver(),
+    true = ExchangeState1 == root_compare,
+
+    % Rehash some entries and confirm root_compare still matches, as 
+    % rehash doesn't do anything
+    ok = lists:foreach(RehashFun([VNN, VNP]), RehashList),
+    {ok, _P1a, GUID1a} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                LogNotRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID1a]),
+    {ExchangeState1a, 0} = testutil:start_receiver(),
+    true = ExchangeState1a == root_compare,
+
+    % Compare the two stores using an AAE fold - and prove that AAE fold is
+    % working as expected
+    Bucket = 
+        case TupleBuckets of
+            true ->
+                {?BUCKET_TYPE, integer_to_binary(3)};
+            false ->
+                 integer_to_binary(3)
+        end,
+    StartKey = list_to_binary(string:right(integer_to_list(10), 6, $0)),
+    EndKey = list_to_binary(string:right(integer_to_list(50), 6, $0)),
+    Elements = [{sibcount, null}, {clock, null}, {hash, null}],
+    InitAcc = {[], 0},
+    FoldKRFun = 
+        fun(FB, FK, FEs, {KCHAcc, SCAcc}) ->
+            true = FB == Bucket,
+            true = FK >= StartKey,
+            true = FK < EndKey,
+            {clock, FC} = lists:keyfind(clock, 1, FEs),
+            {hash, FH} = lists:keyfind(hash, 1, FEs),
+            {sibcount, FSC} = lists:keyfind(sibcount, 1, FEs),
+            {lists:usort([{FK, FC, FH}|KCHAcc]), SCAcc + FSC}
+        end,
+    
+    {async, VNNF} = 
+        mock_kv_vnode:fold_aae(VNN, 
+                                {key_range, Bucket, StartKey, EndKey},
+                                all,
+                                FoldKRFun, 
+                                InitAcc,
+                                Elements),
+    {async, VNPF} = 
+        mock_kv_vnode:fold_aae(VNP, 
+                                {key_range, Bucket, StartKey, EndKey},
+                                all,
+                                FoldKRFun, 
+                                InitAcc,
+                                Elements),
+    
+    {VNNF_KL, VNNF_SC} = VNNF(),
+    {VNPF_KL, VNPF_SC} = VNPF(),
+    true = VNNF_SC == 8,
+    true = VNPF_SC == 8,
+    true = lists:usort(VNNF_KL) == lists:usort(VNPF_KL),
+    true = length(VNNF_KL) == 8,
+    true = length(VNPF_KL) == 8,
+    
+    [{K1, C1, H1}|Rest] = VNNF_KL,
+    [{K2, C2, H2}|_Rest] = Rest,
+    BinaryKey1 = aae_util:make_binarykey(Bucket, K1),
+    BinaryKey2 = aae_util:make_binarykey(Bucket, K2),
+    SegmentID1 = 
+        leveled_tictac:get_segment(
+            element(1, leveled_tictac:tictac_hash(BinaryKey1, <<>>)), 
+            small),
+    SegmentID2 = 
+        leveled_tictac:get_segment(
+            element(1, leveled_tictac:tictac_hash(BinaryKey2, <<>>)), 
+            small),
+    io:format("Looking for Segment IDs K1 ~w ~w K2 ~w ~w~n",
+                [K1, SegmentID1, K2, SegmentID2]),
+
+    {async, VNNF_SL} = 
+        mock_kv_vnode:fold_aae(VNN, 
+                                {key_range, Bucket, StartKey, EndKey},
+                                {segments, [SegmentID1, SegmentID2], small},
+                                FoldKRFun, 
+                                InitAcc,
+                                Elements),
+    {async, VNPF_SL} = 
+        mock_kv_vnode:fold_aae(VNP, 
+                                {key_range, Bucket, StartKey, EndKey},
+                                {segments, [SegmentID1, SegmentID2], small},
+                                FoldKRFun, 
+                                InitAcc,
+                                Elements),
+    {[{K1, C1, H1}, {K2, C2, H2}], 2} = VNNF_SL(),
+    {[{K1, C1, H1}, {K2, C2, H2}], 2} = VNPF_SL(),
+
+    % Make change to one vnode only (the parallel one)
+    Idx1 = erlang:phash2(RogueObj1#r_object.key) rem length(IndexNs),
+    mock_kv_vnode:put(VNP, RogueObj1, lists:nth(Idx1 + 1, IndexNs), []),
+
+    % Exchange between nodes to expose difference
+    {ok, _P2, GUID2} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID2]),
+    {ExchangeState2, 1} = testutil:start_receiver(),
+    true = ExchangeState2 == clock_compare,
+
+    % Make change to one vnode only (the native one)
+    Idx2 = erlang:phash2(RogueObj2#r_object.key) rem length(IndexNs),
+    mock_kv_vnode:put(VNN, RogueObj2, lists:nth(Idx2 + 1, IndexNs), []),
+
+    % Exchange between nodes to expose differences (one in VNN, one in VNP)
+    {ok, _P3, GUID3} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNN), IndexNs}],
+                                [{exchange_vnodesendfun(VNP), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID3]),
+    {ExchangeState3, 2} = testutil:start_receiver(),
+    true = ExchangeState3 == clock_compare,
+
+    {RebuildN, false} = mock_kv_vnode:rebuild(VNN, false),
+    {RebuildP, false} = mock_kv_vnode:rebuild(VNP, false),
+    % Discover Next rebuild times - should be in the future as both stores
+    % were started empty, and hence without the need to rebuild
+    io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildN, RebuildP]),
+    true = RebuildN > os:timestamp(),
+    true = RebuildP > os:timestamp(),
+
+    ok = mock_kv_vnode:close(VNN),
+    ok = mock_kv_vnode:close(VNP),
+
+    % Restart the vnodes, confirm next rebuilds are still in the future 
+    % between startup and shutdown the next_rebuild will be rescheduled to
+    % a different time, as the look at the last rebuild time and schedule 
+    % forward from there.
+    {ok, VNNa} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
+    {ok, VNPa} = mock_kv_vnode:open(MockPathP, parallel, IndexNs, PreflistFun),
+    {RebuildNa, false} = mock_kv_vnode:rebuild(VNNa, false),
+    {RebuildPa, false} = mock_kv_vnode:rebuild(VNPa, false),
+    io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildNa, RebuildPa]),
+    true = RebuildNa > os:timestamp(),
+    true = RebuildPa > os:timestamp(),
+
+    % Exchange between nodes to expose differences (one in VNN, one in VNP)
+    % Should still discover the same difference as when they were closed.
+    {ok, _P3a, GUID3a} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
+                                [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID3a]),
+    {ExchangeState3a, 2} = testutil:start_receiver(),
+    true = ExchangeState3a == clock_compare,
+
+    % Prompts for a rebuild of both stores.  The rebuild is a rebuild of both
+    % the store and the tree in the case of the parallel vnode, and just the
+    % tree in the case of the native rebuild
+    {RebuildNb, true} = mock_kv_vnode:rebuild(VNNa, true),
+    
+    true = RebuildNb > os:timestamp(), 
+        % next rebuild was in the future, and is still scheduled as such
+        % key thing that the ongoing rebuild status is now true (the second 
+        % element of the rebuild response)
+
+    % Now poll to check to see when the rebuild is complete
+    wait_for_rebuild(VNNa),
+
+    % Next rebuild times should now still be in the future
+    {RebuildNc, false} = mock_kv_vnode:rebuild(VNNa, false),
+    {RebuildPc, false} = mock_kv_vnode:rebuild(VNPa, false),
+    true = RebuildPc == RebuildPa, % Should not have changed
+
+    % Following a completed rebuild - the exchange should still work as 
+    % before, spotting two differences
+    {ok, _P3b, GUID3b} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
+                                [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID3b]),
+    {ExchangeState3b, 2} = testutil:start_receiver(),
+    true = ExchangeState3b == clock_compare,
+
+    {RebuildPb, true} = mock_kv_vnode:rebuild(VNPa, true),
+    true = RebuildPb > os:timestamp(),
+
+    % There should now be a rebuild in progress - but immediately check that 
+    % an exchange will still work (spotting the same two differences as before
+    % following a clock_compare)
+    {ok, _P3c, GUID3c} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
+                                [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID3c]),
+    {ExchangeState3c, 2} = testutil:start_receiver(),
+    true = ExchangeState3c == clock_compare,
+
+    wait_for_rebuild(VNPa),
+    {RebuildNd, false} = mock_kv_vnode:rebuild(VNNa, false),
+    {RebuildPd, false} = mock_kv_vnode:rebuild(VNPa, false),
+    true = RebuildNd == RebuildNc,
+    true = RebuildPd > os:timestamp(),
+    
+    % Rebuild now complete - should get the same result for an exchange
+    {ok, _P3d, GUID3d} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
+                                [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID3d]),
+    {ExchangeState3d, 2} = testutil:start_receiver(),
+    true = ExchangeState3d == clock_compare,
+
+    % Delete some keys - and see the size of the delta increase
+    ok = lists:foreach(DeleteFun([VNPa]), DeleteList2),
+    {ok, _P4a, GUID4a} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
+                                [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID4a]),
+    {ExchangeState4a, 32} = testutil:start_receiver(),
+    true = ExchangeState4a == clock_compare,
+    % Balance the deletions
+    ok = lists:foreach(DeleteFun([VNNa]), DeleteList2),
+    {ok, _P4b, GUID4b} = 
+        aae_exchange:start([{exchange_vnodesendfun(VNNa), IndexNs}],
+                                [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                NullRepairFun,
+                                ReturnFun),
+    io:format("Exchange id ~s~n", [GUID4b]),
+    {ExchangeState4b, 2} = testutil:start_receiver(),
+    true = ExchangeState4b == clock_compare,
+
+    % Same exchange - now using tree compare
+    CheckBucketList = [Bucket1, Bucket2],
+    CheckBucketFun = 
+        fun(CheckBucket, Acc) ->
+            CBFilters = {filter, CheckBucket, all, small, all, all, prehash},
+            {ok, _TCCB_P, TCCB_GUID} = 
+                aae_exchange:start(partial,
+                                    [{exchange_vnodesendfun(VNNa), IndexNs}],
+                                    [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                    NullRepairFun,
+                                    ReturnFun,
+                                    CBFilters),
+            io:format("Exchange id for tree compare ~s~n", [TCCB_GUID]),
+            {ExchangeStateTCCB, CBN} = testutil:start_receiver(),
+            true = ExchangeStateTCCB == clock_compare,
+            io:format("~w differences found in bucket ~w~n", 
+                        [CBN, CheckBucket]),
+            Acc + CBN
+        end,
+    true = 2 == lists:foldl(CheckBucketFun, 0, CheckBucketList),
+
+    % Next section is going to test tree_compare with large deltas, and
+    % with a genuine repair fun (one which actually repairs).  Repairs
+    % should happen in stages as the mismatched segment list will at first
+    % be too large - so there will be a down selection in select_ids
+    %
+    % A delta between buckets is created both ways, with bucket3 out of
+    % sync one way, and bucket 4 out of sync th eother way
+
+    true = InitialKeyCount > 2000,
+    RplObjListTC = testutil:gen_riakobjects(2000, [], TupleBuckets),
+    FilterBucket3Fun = fun(RObj) -> RObj#r_object.bucket == Bucket3 end,
+    FilterBucket4Fun = fun(RObj) -> RObj#r_object.bucket == Bucket4 end,
+    RplObjListTC3 = lists:filter(FilterBucket3Fun, RplObjListTC),
+        % Only have changes in Bucket 3
+    RplObjListTC4 = lists:filter(FilterBucket4Fun, RplObjListTC),
+        % Only have changes in Bucket 4
+
+    SingleSidedPutFun =
+        fun(MVN) ->
+            fun(RObj) ->
+                PL = PreflistFun(null, RObj#r_object.key),
+                mock_kv_vnode:put(MVN, RObj, PL, [])
+            end
+        end,
+    lists:foreach(SingleSidedPutFun(VNNa), RplObjListTC3),
+    lists:foreach(SingleSidedPutFun(VNPa), RplObjListTC4),
+
+    NoRepairCheckB3 = CheckBucketFun(Bucket3, 0),
+    NoRepairCheckB4 = CheckBucketFun(Bucket4, 0),
+    true = length(RplObjListTC3) > NoRepairCheckB3,
+    true = length(RplObjListTC4) > NoRepairCheckB4,
+        % this should be less than, as a subset of mismatched segments will
+        % be passed to fetch clocks
+    true = 0 < NoRepairCheckB3,
+    true = 0 < NoRepairCheckB4,
+       
+    RepairListMapFun = fun(RObj) -> {RObj#r_object.key, RObj} end,
+    RepairListTC3 = lists:map(RepairListMapFun, RplObjListTC3),
+    RepairListTC4 = lists:map(RepairListMapFun, RplObjListTC4),
+    GenuineRepairFun =
+        fun(SourceVnode, TargetVnode, RepairList) ->
+            fun(KL) -> 
+                SubRepairFun = 
+                    fun({{RepB, K}, _VCCompare}, Acc) -> 
+                        case lists:keyfind(K, 1, RepairList) of
+                            {K, RObj} ->
+                                PL = PreflistFun(null, K),
+                                ok = mock_kv_vnode:read_repair(SourceVnode,
+                                                                RObj,
+                                                                PL,
+                                                                [TargetVnode]),
+                                Acc + 1;
+                            false ->
+                                io:format("Missing from repair list ~w ~w~n",
+                                            [RepB, K]),
+                                Acc
+                        end
+                    end,
+                Repaired = lists:foldl(SubRepairFun, 0, KL),
+                io:format("~w keys repaired to vnode ~w~n",
+                    [Repaired, TargetVnode]) 
+            end
+        end,
+    RepairFunTC3 = GenuineRepairFun(VNNa, VNPa, RepairListTC3),
+    RepairFunTC4 = GenuineRepairFun(VNPa, VNNa, RepairListTC4),
+
+    RepairBucketFun = 
+        fun(CheckBucket, TargettedRepairFun, Hash) ->
+            CBFilters = {filter, CheckBucket, all, small, all, all, Hash},
+            {ok, _TCCB_P, TCCB_GUID} = 
+                aae_exchange:start(partial,
+                                    [{exchange_vnodesendfun(VNNa), IndexNs}],
+                                    [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                    TargettedRepairFun,
+                                    ReturnFun,
+                                    CBFilters),
+            io:format("Exchange id for tree compare ~s~n", [TCCB_GUID]),
+            testutil:start_receiver()
+        end,
+    
+    FoldRepair3Fun = 
+        fun(_I, Acc) ->
+            case RepairBucketFun(Bucket3, RepairFunTC3, prehash) of
+                {clock_compare, Count3} ->
+                    Acc + Count3;
+                {tree_compare, 0} ->
+                    Acc
+            end
+        end,
+    TotalRepairs3 = lists:foldl(FoldRepair3Fun, 0, lists:seq(1, 6)),
+    io:format("Repaired ~w from list of length ~w~n",
+                [TotalRepairs3, length(RepairListTC3)]),
+    true = length(RepairListTC3) =< TotalRepairs3,
+    % **
+
+    FoldRepair4Fun = 
+        fun(_I, Acc) ->
+            case RepairBucketFun(Bucket4, RepairFunTC4, {rehash, 5000}) of
+                {clock_compare, Count4} ->
+                    Acc + Count4;
+                {tree_compare, 0} ->
+                    Acc
+            end
+        end,
+    TotalRepairs4 = lists:foldl(FoldRepair4Fun, 0, lists:seq(1, 6)),
+    io:format("Repaired ~w from list of length ~w~n",
+                [TotalRepairs4, length(RepairListTC4)]),
+    true = length(RepairListTC4) =< TotalRepairs4,
+    % **
+    % ** - note the use of "=<" here ..appears to eb sometimes out by one
+    % - timing issues?
+    % TODO: Clarify as to why, and is it sometimes more than 1s
+
+    % Check with a key range.  Testing with a modified range requires more
+    % effort as the objects don't have a last modified date
+
+    LimiterCheckBucketFun = 
+        fun(LimiterFilters) ->
+            {ok, _TCCB_P, TCCB_GUID} = 
+                aae_exchange:start(partial,
+                                    [{exchange_vnodesendfun(VNNa), IndexNs}],
+                                    [{exchange_vnodesendfun(VNPa), IndexNs}],
+                                    LogNotRepairFun,
+                                    ReturnFun,
+                                    LimiterFilters),
+            io:format("Exchange id for tree compare ~s~n", [TCCB_GUID]),
+            testutil:start_receiver()
+        end,
+    CheckFiltersB = 
+        {filter, Bucket3, all, small, all, all, prehash},
+        % verify no hangover going into the key range test
+    true = {tree_compare, 0} == LimiterCheckBucketFun(CheckFiltersB),
+
+    RplObjListMR = testutil:gen_riakobjects(2000, [], TupleBuckets),
+    RplObjListMR3 = lists:filter(FilterBucket3Fun, RplObjListMR),
+
+    lists:foreach(SingleSidedPutFun(VNNa), RplObjListMR3),
+
+    RepairListMR3 = lists:map(RepairListMapFun, RplObjListMR3),
+    RLMR3_SL = lists:sublist(lists:ukeysort(1, RepairListMR3), 50, 50),
+    [{SK, _SObj}|_RestMRSL] = RLMR3_SL,
+    {EK, _EObj} = lists:last(RLMR3_SL),
+    io:format("StartKey ~s EndKey ~s in Range test~n", 
+                [binary_to_list(SK), binary_to_list(EK)]),
+
+    CheckFiltersKR = 
+        {filter, Bucket3, {SK, EK}, small, all, all, prehash},
+    true = {clock_compare, 50} == LimiterCheckBucketFun(CheckFiltersKR),
+
+    % Shutdown and clear down files
+    ok = mock_kv_vnode:close(VNNa),
+    ok = mock_kv_vnode:close(VNPa),
+    RootPath = testutil:reset_filestructure().
+
+
+wait_for_rebuild(Vnode) ->
+    RebuildComplete = 
+        lists:foldl(fun(Wait, Complete) ->
+                            case Complete of 
+                                true ->
+                                    true;
+                                false ->
+                                    timer:sleep(Wait),
+                                    {_TSN, RSN} = 
+                                        mock_kv_vnode:rebuild(Vnode, false),
+                                    % Waiting for rebuild status to be false 
+                                    % on both vnodes, which would indicate
+                                    % that both rebuilds have completed
+                                    (not RSN)
+                            end
+                        end,
+                        false,
+                        [1000, 2000, 3000, 5000, 8000, 13000, 21000]),
+    
+    % Both rebuilds have completed
+    true = RebuildComplete == true.
+
+
+mock_vnode_coveragefold_nativemedium(_Config) ->
+    mock_vnode_coveragefolder(native, 50000, true).
+
+mock_vnode_coveragefold_nativesmall(_Config) ->
+    mock_vnode_coveragefolder(native, 5000, false).
+
+mock_vnode_coveragefold_parallelsmall(_Config) ->
+    mock_vnode_coveragefolder(parallel, 5000, true).
+
+mock_vnode_coveragefold_parallelmedium(_Config) ->
+    mock_vnode_coveragefolder(parallel, 50000, false).
+
+
+
+mock_vnode_coveragefolder(Type, InitialKeyCount, TupleBuckets) ->
+    % This should load a set of 4 vnodes, with the data partitioned across the
+    % vnodes n=2 to provide for 2 different coverage plans.
+    %
+    % After the load, an exchange can confirm consistency between the coverage 
+    % plans.  Then run some folds to make sure that the folds produce the 
+    % expected results 
+    RootPath = testutil:reset_filestructure(),
+    MockPathN1 = filename:join(RootPath, "mock_native1/"),
+    MockPathN2 = filename:join(RootPath, "mock_native2/"),
+    MockPathN3 = filename:join(RootPath, "mock_native3/"),
+    MockPathN4 = filename:join(RootPath, "mock_native4/"),
+    
+    IndexNs = 
+        [{1, 2}, {2, 2}, {3, 2}, {0, 2}],
+    PreflistFun = 
+        fun(_B, K) ->
+            Idx = erlang:phash2(K) rem length(IndexNs),
+            lists:nth(Idx + 1, IndexNs)
+        end,
+
+    % Open four vnodes to take two of the rpeflists each
+    % - this isintended to replicate a ring-size=4, n-val=2 ring 
+    {ok, VNN1} = 
+        mock_kv_vnode:open(MockPathN1, Type, [{1, 2}, {0, 2}], PreflistFun),
+    {ok, VNN2} = 
+        mock_kv_vnode:open(MockPathN2, Type, [{2, 2}, {1, 2}], PreflistFun),
+    {ok, VNN3} = 
+        mock_kv_vnode:open(MockPathN3, Type, [{3, 2}, {2, 2}], PreflistFun),
+    {ok, VNN4} = 
+        mock_kv_vnode:open(MockPathN4, Type, [{0, 2}, {3, 2}], PreflistFun),
+
+    % Mapping of preflists to [Primary, Secondary] vnodes
+    RingN =
+        [{{1, 2}, [VNN1, VNN2]}, {{2, 2}, [VNN2, VNN3]}, 
+            {{3, 2}, [VNN3, VNN4]}, {{0, 2}, [VNN4, VNN1]}],
+
+    % Add each key to the vnode at the head of the preflist, and then push the
+    % change to the one at the tail.  
+    PutFun = 
+        fun(Ring) ->
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                {PL, [Primary, Secondary]} = lists:keyfind(PL, 1, Ring),
+                mock_kv_vnode:put(Primary, Object, PL, [Secondary])
+            end
+        end,
+
+    ObjList = testutil:gen_riakobjects(InitialKeyCount, [], TupleBuckets),
+    ok = lists:foreach(PutFun(RingN), ObjList),
+
+    % Provide two coverage plans, equivalent to normal ring coverage plans
+    % with offset=0 and offset=1
+    AllPrimariesMap =
+        fun({IndexN, [Pri, _FB]}) ->
+            {exchange_vnodesendfun(Pri), [IndexN]}
+        end,
+    AllSecondariesMap =
+        fun({IndexN, [_Pri, FB]}) ->
+            {exchange_vnodesendfun(FB), [IndexN]}
+        end,
+    AllPrimaries = lists:map(AllPrimariesMap, RingN),
+    AllSecondaries = lists:map(AllSecondariesMap, RingN),
+
+    RPid = self(),
+    RepairFun = fun(_KL) -> null end,  
+    ReturnFun = fun(R) -> RPid ! {result, R} end,
+
+    {ok, _P1, GUID1} = 
+        aae_exchange:start(AllPrimaries, AllSecondaries, RepairFun, ReturnFun),
+    io:format("Exchange id ~s~n", [GUID1]),
+    {ExchangeState1, 0} = testutil:start_receiver(),
+    true = ExchangeState1 == root_compare,
+
+
+    % Fold over a valid coverage plan to find siblings (there are none) 
+    SibCountFoldFun =
+        fun(B, K, V, {NoSibAcc, SibAcc}) ->
+            {sibcount, SC} = lists:keyfind(sibcount, 1, V),
+            case SC of 
+                1 -> {NoSibAcc + 1, SibAcc};
+                _ -> {NoSibAcc, [{B, K}|SibAcc]}
+            end
+        end,
+    
+    SWF1 = os:timestamp(),
+    {async, Folder1} = 
+        mock_kv_vnode:fold_aae(VNN1, all, all, SibCountFoldFun, 
+                                {0, []}, [{sibcount, null}]),
+    {async, Folder3} = 
+        mock_kv_vnode:fold_aae(VNN3, all, all, SibCountFoldFun, 
+                                Folder1(), [{sibcount, null}]),
+    {SC1, SibL1} = Folder3(),
+    io:format("Coverage fold took ~w with output ~w for store ~w~n", 
+                [timer:now_diff(os:timestamp(), SWF1),SC1, Type]),
+    true = SC1 == InitialKeyCount,
+    true = [] == SibL1,
+
+    SWF2 = os:timestamp(),
+    BucketListA = 
+        case TupleBuckets of
+            true ->
+                [{?BUCKET_TYPE, integer_to_binary(0)},
+                    {?BUCKET_TYPE, integer_to_binary(1)}];
+            false ->
+                [integer_to_binary(0), integer_to_binary(1)]
+        end,
+    {async, Folder2} = 
+        mock_kv_vnode:fold_aae(VNN2, 
+                                {buckets, BucketListA}, all, 
+                                SibCountFoldFun, {0, []},
+                                [{sibcount, null}]),
+    {async, Folder4} = 
+        mock_kv_vnode:fold_aae(VNN4, 
+                                {buckets, BucketListA}, all,
+                                SibCountFoldFun, Folder2(),
+                                [{sibcount, null}]),
+    {SC2, SibL2} = Folder4(),
+    io:format("Coverage fold took ~w with output ~w for store ~w~n", 
+                [timer:now_diff(os:timestamp(), SWF2),SC2, Type]),
+    true = SC2 == 2 * (InitialKeyCount div 5),
+    true = [] == SibL2,
+
+    % A fold over two coverage plans to compare the list of {B, K, H, Sz} 
+    % tuples found within the coverage plans
+    HashSizeFoldFun =
+        fun(B, K, V, Acc) ->
+            {hash, H} = lists:keyfind(hash, 1, V),
+            {size, Sz} = lists:keyfind(size, 1, V),
+            [{B, K, H, Sz}|Acc]
+        end,
+
+    {async, Folder1HS} = 
+        mock_kv_vnode:fold_aae(VNN1, all, all, HashSizeFoldFun, 
+                                [], [{hash, null}, {size, null}]),
+    {async, Folder3HS} = 
+        mock_kv_vnode:fold_aae(VNN3, all, all, HashSizeFoldFun, 
+                                Folder1HS(), [{hash, null}, {size, null}]),
+    BKHSzL1 = Folder3HS(),
+    true = length(BKHSzL1) == InitialKeyCount,
+
+    {async, Folder2HS} = 
+        mock_kv_vnode:fold_aae(VNN2, all, all, HashSizeFoldFun, 
+                                [], [{hash, null}, {size, null}]),
+    {async, Folder4HS} = 
+        mock_kv_vnode:fold_aae(VNN4, all, all, HashSizeFoldFun, 
+                                Folder2HS(), [{hash, null}, {size, null}]),
+    BKHSzL2 = Folder4HS(),
+    true = length(BKHSzL2) == InitialKeyCount,
+
+    true = lists:usort(BKHSzL2) == lists:usort(BKHSzL1),
+
+    ok = mock_kv_vnode:close(VNN1),
+    ok = mock_kv_vnode:close(VNN2),
+    ok = mock_kv_vnode:close(VNN3),
+    ok = mock_kv_vnode:close(VNN4),
+    RootPath = testutil:reset_filestructure().
+
+
+exchange_vnodesendfun(MVN) -> testutil:exchange_vnodesendfun(MVN).

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -1,0 +1,199 @@
+-module(testutil).
+
+-export([gen_keys/2,
+            gen_keys/3,
+            put_keys/3,
+            put_keys/4,
+            remove_keys/3,
+            gen_riakobjects/3]).
+-export([calc_preflist/2]).
+-export([start_receiver/0, 
+            exchange_sendfun/1,
+            exchange_vnodesendfun/1,
+            repair_fun/3]).
+-export([reset_filestructure/0,
+            reset_filestructure/2]).
+
+-include("testutil.hrl").
+
+-define(ROOT_PATH, "test/").
+
+reset_filestructure() ->
+    reset_filestructure(0, ?ROOT_PATH).
+    
+reset_filestructure(Wait, RootPath) ->
+    io:format("Waiting ~w ms to give a chance for all file closes " ++
+                 "to complete~n", [Wait]),
+    timer:sleep(Wait),
+    clear_all(RootPath),
+    RootPath.
+
+clear_all(RootPath) ->
+    ok = filelib:ensure_dir(RootPath),
+    {ok, FNs} = file:list_dir(RootPath),
+    FoldFun =
+        fun(FN) ->
+            FFP = filename:join(RootPath, FN),
+            case filelib:is_dir(FFP) of 
+                true ->
+                    clear_all(FFP ++ "/");
+                false ->
+                    case filelib:is_file(FFP) of 
+                        true ->
+                            file:delete(FFP);
+                        false ->
+                            ok 
+                    end
+            end
+        end,
+    lists:foreach(FoldFun, FNs).
+
+gen_keys(KeyList, Count) ->
+    gen_keys(KeyList, Count, 0).
+
+gen_keys(KeyList, Count, Floor) when Count == Floor ->
+    KeyList;
+gen_keys(KeyList, Count, Floor) ->
+    Bucket = integer_to_binary(Count rem 5),  
+    Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
+    VersionVector = add_randomincrement([]),
+    gen_keys([{Bucket, Key, VersionVector}|KeyList], 
+                Count - 1,
+                Floor).
+
+put_keys(Cntrl, NVal, KL) ->
+    put_keys(Cntrl, NVal, KL, none).
+
+put_keys(_Cntrl, _Nval, [], _PrevVV) ->
+    ok;
+put_keys(Cntrl, Nval, [{Bucket, Key, VersionVector}|Tail], PrevVV) ->
+    ok = aae_controller:aae_put(Cntrl, 
+                                calc_preflist(Key, Nval), 
+                                Bucket, 
+                                Key, 
+                                VersionVector, 
+                                PrevVV, 
+                                {[os:timestamp()],
+                                    term_to_binary([{clock, VersionVector}])}),
+    put_keys(Cntrl, Nval, Tail, PrevVV).
+
+remove_keys(_Cntrl, _Nval, []) ->
+    ok;
+remove_keys(Cntrl, Nval, [{Bucket, Key, _VV}|Tail]) ->
+    ok = aae_controller:aae_put(Cntrl, 
+                                calc_preflist(Key, Nval), 
+                                Bucket, 
+                                Key, 
+                                none, 
+                                undefined, 
+                                <<>>),
+    remove_keys(Cntrl, Nval, Tail).
+
+
+gen_riakobjects(0, ObjectList, _TupleBuckets) ->
+    ObjectList;
+gen_riakobjects(Count, ObjectList, TupleBuckets) ->
+    Bucket = 
+        case TupleBuckets of
+            true ->
+                {?BUCKET_TYPE, integer_to_binary(Count rem 5)};
+            false ->
+                integer_to_binary(Count rem 5)
+        end,
+    Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
+    Value = leveled_rand:rand_bytes(512),
+    Obj = #r_object{bucket = Bucket,
+                    key = Key,
+                    contents = [#r_content{value = Value}]},
+    gen_riakobjects(Count - 1, [Obj|ObjectList], TupleBuckets).
+
+
+add_randomincrement(Clock) ->
+    RandIncr = leveled_rand:uniform(100),
+    RandNode = lists:nth(leveled_rand:uniform(9), 
+                            ["a", "b", "c", "d", "e", "f", "g", "h", "i"]),
+    UpdClock = 
+        case lists:keytake(RandNode, 1, Clock) of 
+            false ->
+                [{RandNode, RandIncr}|Clock];
+            {value, {RandNode, Incr0}, Rest} ->
+                [{RandNode, Incr0 + RandIncr}|Rest]
+        end,
+    lists:usort(UpdClock).
+
+calc_preflist(Key, 2) ->
+    case erlang:phash2(Key) band 3 of 
+        0 ->
+            {2, 0};
+        _ ->
+            {2, 1}
+    end;
+calc_preflist(Key, 3) ->
+    case erlang:phash2(Key) band 3 of 
+        0 ->
+            {3, 0};
+        1 ->
+            {3, 1};
+        _ ->
+            {3, 2}
+    end.
+
+start_receiver() ->
+    receive
+        {result, Reply} ->
+            Reply 
+    end.
+
+
+exchange_sendfun(Cntrl) ->
+    SendFun = 
+        fun(Msg, Preflists, Colour) ->
+            RPid = self(),
+            ReturnFun = 
+                fun(R) -> 
+                    aae_exchange:reply(RPid, R, Colour)
+                end,
+            case Msg of 
+                fetch_root ->
+                    aae_controller:aae_mergeroot(Cntrl, 
+                                                    Preflists, 
+                                                    ReturnFun);
+                {fetch_branches, BranchIDs} ->
+                    aae_controller:aae_mergebranches(Cntrl, 
+                                                        Preflists, 
+                                                        BranchIDs, 
+                                                        ReturnFun);
+                {fetch_clocks, SegmentIDs} ->
+                    aae_controller:aae_fetchclocks(Cntrl,
+                                                        Preflists,
+                                                        SegmentIDs,
+                                                        ReturnFun,
+                                                        null)
+            end
+        end,
+    SendFun.
+
+exchange_vnodesendfun(VN) ->
+    fun(Msg, Preflists, Colour) ->
+        RPid = self(),
+        ReturnFun = 
+            fun(R) -> 
+                aae_exchange:reply(RPid, R, Colour)
+            end,
+        mock_kv_vnode:exchange_message(VN, Msg, Preflists, ReturnFun)
+    end.
+
+
+repair_fun(SourceList, Cntrl, NVal) ->
+    Lookup = lists:map(fun({B, K, V}) -> {{B, K}, V} end, SourceList),
+    RepairFun = 
+        fun(BucketKeyL) ->
+            FoldFun =
+                fun({{B0, K0}, _VCDelta}, Acc) -> 
+                    {{B0, K0}, V0} = lists:keyfind({B0, K0}, 1, Lookup),
+                    [{B0, K0, V0}|Acc]
+                end,
+            KVL = lists:foldl(FoldFun, [], BucketKeyL),
+            ok = put_keys(Cntrl, NVal, KVL)
+        end,
+    RepairFun.

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -102,9 +102,11 @@ gen_riakobjects(Count, ObjectList, TupleBuckets) ->
         end,
     Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
     Value = leveled_rand:rand_bytes(512),
+    MD = [{last_modified_date, os:timestamp()}, 
+            {random, leveled_rand:uniform(3)}],
     Obj = #r_object{bucket = Bucket,
                     key = Key,
-                    contents = [#r_content{value = Value}]},
+                    contents = [#r_content{metadata = MD, value = Value}]},
     gen_riakobjects(Count - 1, [Obj|ObjectList], TupleBuckets).
 
 

--- a/test/end_to_end/testutil.hrl
+++ b/test/end_to_end/testutil.hrl
@@ -1,0 +1,16 @@
+
+-record(r_content, {
+                    metadata,
+                    value :: term()
+                    }).
+
+-record(r_object, {
+                    bucket,
+                    key,
+                    contents :: [#r_content{}],
+                    vclock = [],
+                    updatemetadata=dict:store(clean, true, dict:new()),
+                    updatevalue :: term()}).
+
+
+-define(BUCKET_TYPE, <<"BucketType">>).


### PR DESCRIPTION
This combines two significant changes:

The ability for the aae_exchange_fsm to support tree exchanges for dynamically generated trees (covering key ranges and/or modified ranges).

A refactor and expansion of mock vnode testing to make sure more scenarios are covered, and covered in all parallel backends.