### PR TITLE
Mas i1765 asynchandling

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {tag, "0.9.21"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "develop-2.9"}}}
         ]}.

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -63,7 +63,7 @@
 -define(EMPTY_MD, term_to_binary([])).
 -define(SYNC_TIMEOUT, 60000).
     % May depend on x2 underlying 30s timeout
--define(MAX_RUNNER_QUEUEDEPTH, 4).
+-define(MAX_RUNNER_QUEUEDEPTH, 2).
 
 
 -record(state, {key_store :: pid()|undefined,

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -48,7 +48,7 @@
             hash_clocks/2,
             wrapped_splitobjfun/1]).
 
--export([rebuild_worker/1, wait_on_sync/3]).
+-export([rebuild_worker/1, wait_on_sync/5]).
 
 -export([generate_returnfun/2]).
 
@@ -408,7 +408,7 @@ aae_bucketlist(Pid) ->
 %% the controller.
 %% The sync ping will return 'ok'.
 aae_ping(Pid, RequestTime, {sync, Timeout}) ->
-    wait_on_sync(Pid, {ping, RequestTime}, Timeout);
+    wait_on_sync(gen_server, call, Pid, {ping, RequestTime}, Timeout);
 aae_ping(Pid, RequestTime, From) ->
     gen_server:cast(Pid, {ping, RequestTime, From}).
 
@@ -1121,11 +1121,12 @@ hash_clock(none) ->
 hash_clock(Clock) ->
     erlang:phash2(lists:sort(Clock)).
 
--spec wait_on_sync(pid(), tuple(), pos_integer()) -> any().
+-spec wait_on_sync(atom(), atom(), pid(), tuple()|atom(), pos_integer())
+                                                                    -> any().
 %% @doc
 %% Wait on a sync call until timeout - but don't crash on the timeout
-wait_on_sync(Pid, Call, Timeout) ->
-    try gen_server:call(Pid, Call, Timeout)
+wait_on_sync(Mod, Fun, Pid, Call, Timeout) ->
+    try Mod:Fun(Pid, Call, Timeout)
     catch exit:{timeout, _} -> timeout
     end.
 

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -551,6 +551,8 @@ waiting_all_results({reply, not_supported, Colour}, State) ->
                     logs(),
                     State#state.log_levels),
     {stop, normal, State#state{pending_state = not_supported}};
+waiting_all_results({reply, {error, Reason}, _Colour}, State) ->
+    waiting_all_results({error, Reason}, State);
 waiting_all_results({reply, Result, Colour}, State) ->
     aae_util:log("EX007",
                     [Colour, State#state.exchange_id],
@@ -1079,6 +1081,12 @@ connect_error_test() ->
                                 [1000, 1000, 1000])),
     ?assertMatch(false, is_process_alive(Test)).
     
+waiting_for_error_test() ->
+    {stop, normal, _S0} =
+        waiting_all_results({reply, {error, query_backlog}, blue},
+                            #state{exchange_type = full,
+                                    merge_fun = fun merge_clocks/2}).
+
 
 coverage_cheat_test() ->
     {next_state, prepare, _State0} =

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -52,6 +52,7 @@
             store_mput/3,
             store_mload/2,
             store_prompt/2,
+            store_currentstatus/1,
             store_fold/8,
             store_fetchclock/3,
             store_bucketlist/1,
@@ -300,7 +301,7 @@ store_mput(Pid, ObjectSpecs, false) ->
 %% ObjectOp :: add|remove
 %% Segment :: binary() [<<SegmentID:32/integer>>]
 %% Bucket/Key :: binary() 
-%% Value :: {Version, ...} - Tuples may chnage between different version
+%% Value :: {Version, ...} - Tuples may change between different version
 %%
 %% Load requests are only expected whilst loading, and are pushed to the store
 %% while put requests are cached
@@ -319,6 +320,12 @@ store_mload(Pid, ObjectSpecs) ->
 %% calling NotifyFun(Prompt) -> ok.
 store_prompt(Pid, Prompt) ->
     gen_fsm:send_event(Pid, {prompt, Prompt}).
+
+-spec store_currentstatus(pid()) -> {atom(), list()}.
+%% @doc
+%% Get the state and the current GUID
+store_currentstatus(Pid) ->
+    gen_fsm:sync_send_all_state_event(Pid, current_status, ?SYNC_TIMEOUT).
 
 
 -spec store_fold(pid(), 
@@ -1236,13 +1243,6 @@ logs() ->
 store_fold(Pid, RLimiter, SLimiter, FoldObjectsFun, InitAcc, Elements) ->
     store_fold(Pid, RLimiter, SLimiter, all, false, 
                 FoldObjectsFun, InitAcc, Elements).
-
--spec store_currentstatus(pid()) -> {atom(), list()}.
-%% @doc
-%% Included for test functions only - get the manifest
-store_currentstatus(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, current_status).
-
 
 leveled_so_emptybuildandclose_test() ->
     empty_buildandclose_tester(leveled_so).

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -279,9 +279,13 @@ store_destroy(Pid) ->
 %% Bucket/Key :: binary() 
 %% Value :: {Version, ...} - Tuples may chnage between different version
 %% Block can be set to true should a sync version be required to force the
-%% calling process to wait for the queue to be empty
+%% calling process to wait some time for the queue to be empty
 store_mput(Pid, ObjectSpecs, true) ->
-    pong = gen_fsm:sync_send_all_state_event(Pid, ping, ?SYNC_TIMEOUT),
+    aae_controller:wait_on_sync(gen_fsm,
+                                sync_send_all_state_event,
+                                Pid,
+                                ping,
+                                min(20 * ?LOAD_PAUSE, ?SYNC_TIMEOUT)),
     gen_fsm:send_event(Pid, {mput, ObjectSpecs});
 store_mput(Pid, ObjectSpecs, false) ->
     % As the calling process is not waiting hold the keystore up if the backend

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -23,6 +23,7 @@
                 {gen_fsm, sync_send_event, 2},
                 {gen_fsm, sync_send_event, 3},
                 {gen_fsm, sync_send_all_state_event, 2},
+                {gen_fsm, sync_send_all_state_event, 3},
                 {gen_fsm, send_all_state_event, 2}
                 ]}).
 -endif.

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -122,6 +122,7 @@
     % so the fold will represent the state of the store when the request was
     % processed, and not when the fold was run
 -define(USE_SET_FOR_SPEED, 64).
+-define(SYNC_TIMEOUT, 30000).
 
 -type bucket() :: binary()|{binary(),binary()}.
 -type key() :: binary().
@@ -243,7 +244,8 @@ store_nativestart(Path, NativeStoreType, BackendPid, LogLevels) ->
 %% @doc
 %% Get the startup metadata from the store
 store_startupdata(Pid) ->
-    {LastRebuild, IsEmpty} = gen_fsm:sync_send_event(Pid, startup_metadata),
+    {LastRebuild, IsEmpty} =
+        gen_fsm:sync_send_event(Pid, startup_metadata, ?SYNC_TIMEOUT),
     {ok, {LastRebuild, IsEmpty}, Pid}.
 
 
@@ -257,14 +259,14 @@ store_startupdata(Pid) ->
 %%
 %% Startup should always delete the Shutdown GUID in both stores.
 store_close(Pid) ->
-    gen_fsm:sync_send_event(Pid, close, 10000).
+    gen_fsm:sync_send_event(Pid, close, ?SYNC_TIMEOUT).
 
 
 -spec store_destroy(pid()) -> ok.
 %% @doc
 %% Close the store and clear the data if parallel
 store_destroy(Pid) ->
-    gen_fsm:sync_send_event(Pid, destroy, 30000).
+    gen_fsm:sync_send_event(Pid, destroy, ?SYNC_TIMEOUT).
 
 -spec store_mput(pid(), list()) -> ok.
 %% @doc
@@ -337,7 +339,7 @@ store_fetchclock(Pid, Bucket, Key) ->
 %% @doc
 %% List all the buckets in the keystore
 store_bucketlist(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, bucket_list).
+    gen_fsm:sync_send_all_state_event(Pid, bucket_list, infinity).
 
 -spec store_loglevel(pid(), aae_util:log_levels()) -> ok.
 %% @doc

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -600,17 +600,16 @@ handle_event({log_level, LogLevels}, StateName, State) ->
 handle_info(_Msg, StateName, State) ->
     {next_state, StateName, State}.
 
-terminate(_Reason, native, _State) ->
-    ok;
-terminate(normal, _StateName, State) ->
+terminate(normal, StateName, State) when StateName =/= native->
     store_manifest(State#state.root_path, 
                     #manifest{current_guid = State#state.current_guid,
                                 last_rebuild = State#state.last_rebuild},
-                    State#state.log_levels).
+                    State#state.log_levels);
+terminate(_Reason, _StateName, _State) ->
+    ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
-
 
 
 %%%============================================================================

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -99,7 +99,7 @@
                                     {max_journalsize, 10000000},
                                     {compression_method, native},
                                     {compression_point, on_compact}]).
--define(CHANGEQ_LOGFREQ, 10000).
+-define(CHANGEQ_LOGFREQ, 100000).
 -define(STATE_BUCKET, <<"state">>).
 -define(MANIFEST_FN, "keystore"). 
     % filename for Keystore manifes

--- a/src/aae_runner.erl
+++ b/src/aae_runner.erl
@@ -105,7 +105,7 @@ handle_info(timeout, State) ->
     ok = aae_controller:aae_runnerprompt(State#state.aae_controller),
     {noreply, State}.
 
-terminate(normal, State) ->
+terminate(_Reason, State) ->
     _ = maybe_log(State#state.result_size, 
                     State#state.query_time, 
                     State#state.query_count, 

--- a/src/aae_runner.erl
+++ b/src/aae_runner.erl
@@ -156,6 +156,28 @@ logs() ->
 
 -ifdef(TEST).
 
+runner_fail_test() ->
+    {ok, R} = runner_start(undefined),
+    TestProcess = self(),
+    CheckFun =
+        fun(ReturnTuple) ->
+            ?assertMatch(error, element(1, ReturnTuple)),
+            TestProcess ! error
+        end,
+    ReturnFun = aae_controller:generate_returnfun("ABCD", CheckFun),
+    FoldFun = fun() -> throw(noproc) end,
+    SizeFun = fun(_Results) -> 0 end,
+    runner_work(R, {work, FoldFun, ReturnFun, SizeFun}),
+    ?assertMatch(error, start_receiver()),
+    ok = runner_stop(R).
+    
+start_receiver() ->
+    receive
+        Reply ->
+            Reply 
+    end.
+
+
 coverage_cheat_test() ->
     {ok, _State1} = code_change(null, #state{}, null).
 

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -34,6 +34,7 @@
 -define(PENDING_EXT, ".pnd").
 -define(FINAL_EXT, ".aae").
 -define(START_SQN, 1).
+-define(SYNC_TIMEOUT, 30000).
 
 -record(state, {save_sqn = 0 :: integer(),
                 is_restored = false :: boolean(),
@@ -88,7 +89,7 @@ cache_destroy(AAECache) ->
 %% @doc
 %% Close a cache with saving
 cache_close(AAECache) ->
-    gen_server:call(AAECache, close, 30000).
+    gen_server:call(AAECache, close, ?SYNC_TIMEOUT).
 
 -spec cache_alter(pid(), binary(), integer(), integer()) -> ok.
 %% @doc

--- a/src/aae_util.erl
+++ b/src/aae_util.erl
@@ -58,9 +58,9 @@ log(LogRef, Subs, LogBase, SupportedLogLevels) ->
     {LogRef0, {LogLevel, LogText}} = get_logreference(LogRef, LogBase),
     case lists:member(LogLevel, SupportedLogLevels) of
         true ->
-            io:format(format_time() ++ " "
-                        ++ atom_to_list(LogLevel) ++ " "
-                        ++ LogRef0 ++ " ~w "
+            io:format(format_time() ++ "  log_level="
+                        ++ atom_to_list(LogLevel) ++ " log_ref="
+                        ++ LogRef0 ++ " pid=~w "
                         ++ LogText ++ "~n",
                         [self()|Subs]);
         false ->
@@ -90,9 +90,9 @@ log_timer(LogRef, Subs, StartTime, LogBase, SupportedLogLevels) ->
                     US ->
                         " with us_duration=" ++ integer_to_list(US)
                 end,
-            io:format(format_time() ++ " "
-                        ++ atom_to_list(LogLevel) ++ " "
-                        ++ LogRef0 ++ " ~w "
+            io:format(format_time() ++ "  log_level="
+                        ++ atom_to_list(LogLevel) ++ " log_ref="
+                        ++ LogRef0 ++ " pid=~w "
                         ++ LogText
                         ++ DurationText ++ "~n",
                         [self()|Subs]);

--- a/src/kv_index_tictactree.app.src
+++ b/src/kv_index_tictactree.app.src
@@ -1,7 +1,7 @@
 {application, kv_index_tictactree,
  [
   {description, "AAE helper service for KV vnode"},
-  {vsn, "0.9.14"},
+  {vsn, git},
   {registered, []},
   {applications, [
                   kernel,

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -253,6 +253,19 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     {ExchangeState6a, 10} = testutil:start_receiver(),
     true = ExchangeState6a == clock_compare,
 
+    {ok, _P6b, GUID6b} = 
+        aae_exchange:start(full,
+                            [{exchange_sendfun(Cntrl1), [{2,0}]}, 
+                                {exchange_sendfun(Cntrl1), [{2,1}]}],
+                            [{exchange_sendfun(Cntrl2), 
+                                [{3, 0}, {3, 1}, {3, 2}, {3, 3}]}],
+                            RepairFun,
+                            ReturnFun,
+                            none,
+                            [{scan_timeout, 0}]),
+    io:format("Exchange id ~s~n", [GUID6b]),
+    {timeout, 0} = testutil:start_receiver(),
+
     % Nothing repaired last time.  The deltas are all new keys though, so
     % We can repair by adding them in to the other vnode
 

--- a/test/end_to_end/mockvnode_SUITE.erl
+++ b/test/end_to_end/mockvnode_SUITE.erl
@@ -28,15 +28,19 @@ all() -> [
 
 
 loadexchangeandrebuild_stbucketko(_Config) ->
+    mock_vnode_loadexchangeandrebuild_tester(false, parallel_ko),
     mock_vnode_loadexchangeandrebuild_tester(false, parallel_ko).
 
 loadexchangeandrebuild_stbucketso(_Config) ->
+    mock_vnode_loadexchangeandrebuild_tester(false, parallel_so),
     mock_vnode_loadexchangeandrebuild_tester(false, parallel_so).
 
 loadexchangeandrebuild_tuplebucketko(_Config) ->
+    mock_vnode_loadexchangeandrebuild_tester(true, parallel_ko),
     mock_vnode_loadexchangeandrebuild_tester(true, parallel_ko).
 
 loadexchangeandrebuild_tuplebucketso(_Config) ->
+    mock_vnode_loadexchangeandrebuild_tester(true, parallel_so),
     mock_vnode_loadexchangeandrebuild_tester(true, parallel_so).
 
 mock_vnode_loadexchangeandrebuild_tester(TupleBuckets, PType) ->

--- a/test/timeout_test.erl
+++ b/test/timeout_test.erl
@@ -23,8 +23,10 @@ terminate(_Reason, _State) -> ok.
 
 wait_on_sync_test() ->
     {ok, P} = start_link(),
-    ?assertMatch(timeout, aae_controller:wait_on_sync(P, {test}, 100)),
-    ?assertMatch(ok, aae_controller:wait_on_sync(P, {test}, 2000)),
+    ?assertMatch(timeout,
+        aae_controller:wait_on_sync(gen_server, call, P, {test}, 100)),
+    ?assertMatch(ok,
+        aae_controller:wait_on_sync(gen_server, call, P, {test}, 2000)),
     stop().
 
 -endif.


### PR DESCRIPTION
This PR provides a number of changes to improve handling of pressure within the kv_index_tictactree, especially in how it can signal back-pressure to the calling application to reduce workloads.  

In volume tests on a cluster with >2TB per node on 8 nodes, if tictacaae is enabled for the first time in parallel mode when the cluster is under load and subject to deliberate node failures - then vnode crashes may be seen.  In particular these are related to memory leaks caused by overlapping queries, or by timeouts on sync calls within the kv_index_tictcatree process heirarchy.

There are a number of changes merged in here to alleviate this:

- A fix limit on the number of fetch-clocks queries that may concurrently be queued, to prevent memory exhaustion due to snapshots made for queued queries (for whom the calling process will inevitably have timed out before the query is run).

- Make the aae_keystore respect the "pause"  response from the leveled backend when it has a work backlog, and eventually feedback that pause if necessary (e.g. through slowed aae_ping).

- Complete the load of the change queue which is built up during a keystore rebuild, in a yielding loop whilst still in the loading state - rather than sync wait while the whole change queue is forced into the backend, risking timeout and the creation of large bookie memories.

- Allow the transition from rebuild store, to rebuild trees to wait until the loading state has cleared.

- Allow for tree rebuild requests to be queued prior to the snapshot being made, so as not to retain long-lived snapshots for tree rebuilds, which may suffer from hitting snapshot timeout limits.