### PR TITLE
Mas i1824 corruptedobj

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i370-d30-sstmemory"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "develop-3.0"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "develop-3.0"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i370-d30-sstmemory"}}}
         ]}.

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -695,13 +695,12 @@ handle_call({rebuild_store, SplitObjFun}, _From, State)->
                         generate_objectspec(B, K, SegmentID, IdxN,
                                             V, VC, CH, 
                                             State#state.object_splitfun),
-                    UpdSpecL = [ObjSpec|Acc],
                     case length(Acc) >= ?BATCH_LENGTH of
                         true ->
-                            flush_load(State#state.key_store, UpdSpecL),
+                            flush_load(State#state.key_store, [ObjSpec|Acc]),
                             [];
                         false ->
-                            [ObjSpec|UpdSpecL]
+                            [ObjSpec|Acc]
                     end
                 end,
             FinishFun =

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -1649,11 +1649,11 @@ fetch_clock_test() ->
     % When fetching clocks we may have multiple matches on a segment ID
     % Want to prove that here.  Rather than trying to force a hash collision
     % on the segment ID, we will just generate false segment IDs
-    ObjSplitFun = fun(static) -> {0, 1, 0, null} end,
+    ObjSplitFun = fun(<<"static">>) -> {0, 1, 0, null} end,
     WrappedFun = aae_controller:wrapped_splitobjfun(ObjSplitFun),
     GenVal =
         fun(Clock) ->
-            generate_value({1, 3}, 1, Clock, 0, WrappedFun(static))
+            generate_value({1, 3}, 1, Clock, 0, WrappedFun(<<"static">>))
         end,
     Spc1 = define_addobjectspec(<<"B1">>, <<"K2">>, GenVal([{"a", 1}])),
     Spc2 = define_addobjectspec(<<"B1">>, <<"K3">>, GenVal([{"b", 1}])),


### PR DESCRIPTION
When rebuilding the store in parallel mode, if an object is corrupted so it cannot be loaded, the corruption can be caught and the object skipped.  It is also possible to pass in a function to perform a specific action when the exception is detected (e.g. prompt read repair).