### PR TITLE
Mas i370 patch e

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i370-patchE"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "develop-3.0"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i370-patchD"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i370-patchE"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {profiles,
  [{eqc, [{deps, [meck, fqc]},
     {erl_opts, [debug_info,  {d, 'EQC'}]},
-    {extra_src_dirs, ["test/property"]},
+    {extra_src_dirs, ["test/end_to_end", "test/property"]},
     {plugins, [rebar_eqc]}
    ]},
   {test, [{extra_src_dirs, ["test/end_to_end", "test/property"]}
@@ -19,5 +19,5 @@
 {xref_checks, [undefined_function_calls,undefined_functions]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {tag, "1.0.8"}}}
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled", {branch, "mas-i370-patchD"}}}
         ]}.

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -97,11 +97,14 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(LEVELED_BACKEND_OPTS, [{cache_size, 2000},
-                                    {sync_strategy, none},
-                                    {max_journalsize, 100000000},
-                                    {compression_method, native},
-                                    {compression_point, on_receipt}]).
+-define(LEVELED_BACKEND_OPTS, 
+    [{cache_size, 2000},
+        {sync_strategy, none},
+        {max_journalsize, 100000000},
+        {compression_method, native},
+        {compression_point, on_receipt},
+        {snapshot_timeout_short, 3600},
+        {snapshot_timeout_long, 172800}]).
 -define(CHANGEQ_LOGFREQ, 100000).
 -define(STATE_BUCKET, <<"state">>).
 -define(MANIFEST_FN, "keystore"). 

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -453,6 +453,7 @@ handle_call(bucketlist_aae, _From, State) ->
     {reply, R, State};
 handle_call(close, _From, State) ->
     ok = aae_controller:aae_close(State#state.aae_controller),
+    ok = leveled_bookie:book_close(State#state.vnode_store),
     {stop, normal, ok, State}.
 
 handle_cast({push, Bucket, Key, UpdClock, ObjectBin, IndexN}, State) ->


### PR DESCRIPTION
Longer snapshot timeouts by default - to handle very large vnodes.  

Fix to errors in tests due to mock_vnode shutdown