### PR TITLE
Pass in leveled configuration items at startup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,5 +22,5 @@
 {ct_opts, [{dir, ["test/end_to_end"]}]}.
 
 {deps, [
-        {leveled, ".*", {git, "https://github.com/nhs-riak/leveled", {branch, "nhse-develop"}}}
+        {leveled, ".*", {git, "https://github.com/OpenRiak/leveled", {branch, "openriak-3.2"}}}
         ]}.

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -25,6 +25,7 @@
 
 -export([aae_start/6,
             aae_start/7,
+            aae_start/8,
             aae_nextrebuild/1,
             aae_put/7,
             aae_close/1,
@@ -44,7 +45,8 @@
             aae_bucketlist/1,
             aae_loglevel/2,
             aae_ping/3,
-            aae_runnerprompt/1]).
+            aae_runnerprompt/1
+        ]).
 
 -export([foldobjects_buildtrees/2,
             hash_clocks/2,
@@ -68,7 +70,6 @@
     % May depend on x2 underlying 30s timeout
 -define(MAX_RUNNER_QUEUEDEPTH, 4).
 
-
 -record(state, {key_store :: pid()|undefined,
                 tree_caches = [] :: tree_caches(),
                 index_ns = [] :: list(responsible_preflist()),
@@ -87,14 +88,19 @@
                 queue_backlog = false :: boolean(),
                 block_next_put = false :: boolean()}).
 
--record(options, {keystore_type :: keystore_type(),
-                    store_isempty :: boolean(),
-                    rebuild_schedule :: rebuild_schedule(),
-                    index_ns :: list(responsible_preflist()),
-                    object_splitfun,
-                    root_path :: list(),
-                    log_levels :: aae_util:log_levels()|undefined}).
-
+-record(options,
+    {
+        keystore_type :: keystore_type(),
+        store_isempty :: boolean(),
+        rebuild_schedule :: rebuild_schedule(),
+        index_ns :: list(responsible_preflist()),
+        object_splitfun,
+        root_path :: list(),
+        log_levels :: aae_util:log_levels()|undefined,
+        leveled_options :: aae_keystore:leveled_options()
+    }
+).
+    
 -type controller_state() :: #state{}.
 
 -type responsible_preflist() :: {integer(), integer()}. 
@@ -156,42 +162,47 @@
 %%% API
 %%%============================================================================
 
--spec aae_start(keystore_type(), 
-                boolean(), 
-                rebuild_schedule(),
-                list(responsible_preflist()), 
-                list(),
-                object_splitter()) -> {ok, pid()}.
+aae_start(KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun) ->
+    aae_start(
+        KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, undefined
+    ).
+
+aae_start(KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels) ->
+    LeveledOpts = aae_keystore:store_generate_backendoptions(),
+    aae_start(
+        KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels, LeveledOpts
+    ).
+
+-spec aae_start(
+    keystore_type(), 
+    boolean(), 
+    rebuild_schedule(),
+    list(responsible_preflist()), 
+    list(),
+    object_splitter(),
+    aae_util:log_levels()|undefined,
+    aae_keystore:leveled_options()) -> {ok, pid()}.
 %% @doc
 %% Start an AAE controller 
 %% The ObjectsplitFun must take a vnode object in a binary form and output 
 %% {Size, SibCount, IndexHash, LMD, MD}.  If the SplitFun previously outputted
 %% {Size, SibCount, IndexHash, null} that output will be converted
-aae_start(KeyStoreT, IsEmpty, RebuildSch, Preflists, RootPath, ObjSplitFun) ->
-    aae_start(KeyStoreT, IsEmpty, RebuildSch,
-                Preflists, RootPath, ObjSplitFun, undefined).
-
--spec aae_start(keystore_type(), 
-                boolean(), 
-                rebuild_schedule(),
-                list(responsible_preflist()), 
-                list(),
-                object_splitter(),
-                aae_util:log_levels()|undefined) -> {ok, pid()}.
-
-aae_start(KeyStoreT, IsEmpty, RebuildSch,
-                Preflists, RootPath, ObjSplitFun, LogLevels) ->
+aae_start(
+        KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels, LeveledOpts
+    ) ->
     WrapObjSplitFun = wrapped_splitobjfun(ObjSplitFun),
     AAEopts =
-        #options{keystore_type = KeyStoreT,
-                    store_isempty = IsEmpty,
-                    rebuild_schedule = RebuildSch,
-                    index_ns = Preflists,
-                    root_path = RootPath,
-                    object_splitfun = WrapObjSplitFun,
-                    log_levels = LogLevels},
+        #options{
+            keystore_type = KeyStoreT,
+            store_isempty = IsEmpty,
+            rebuild_schedule = RS,
+            index_ns = PLs,
+            root_path = Path,
+            object_splitfun = WrapObjSplitFun,
+            log_levels = LogLevels,
+            leveled_options = LeveledOpts
+        },
     gen_server:start(?MODULE, [AAEopts], []).
-
 
 -spec aae_nextrebuild(pid()) -> erlang:timestamp().
 %% @doc
@@ -463,6 +474,7 @@ aae_ping(Pid, RequestTime, From) ->
 aae_runnerprompt(Pid) ->
     gen_server:cast(Pid, runner_prompt).
 
+
 %%%============================================================================
 %%% gen_server callbacks
 %%%============================================================================
@@ -478,45 +490,56 @@ init([Opts]) ->
         case Opts#options.keystore_type of 
             {parallel, StoreType} ->
                 StoreRP = filename:join([RootPath, StoreType, ?STORE_PATH]),
+                LeveledOpts = Opts#options.leveled_options,
                 {ok, {LastRebuild, IsEmpty}, Pid} =
-                    aae_keystore:store_parallelstart(StoreRP,
-                                                        StoreType,
-                                                        LogLevels),
+                    aae_keystore:store_parallelstart(
+                        StoreRP, StoreType, LogLevels, LeveledOpts),
                 case Opts#options.store_isempty of 
                     IsEmpty ->
                         RebuildTS = 
                             schedule_rebuild(LastRebuild, RebuildSchedule),
-                        {ok, #state{key_store = Pid, 
-                                        next_rebuild = RebuildTS,
-                                        rebuild_schedule = RebuildSchedule,
-                                        reliable = true,
-                                        parallel_keystore = true}};
+                        {
+                            ok,
+                            #state{
+                                key_store = Pid, 
+                                next_rebuild = RebuildTS,
+                                rebuild_schedule = RebuildSchedule,
+                                reliable = true,
+                                parallel_keystore = true
+                            }
+                        };
                     StoreState ->
-                        aae_util:log("AAE01", 
-                                        [StoreState, IsEmpty],
-                                        logs(),
-                                        LogLevels),
-                        {ok, #state{key_store = Pid, 
-                                        next_rebuild = os:timestamp(), 
-                                        rebuild_schedule = RebuildSchedule,
-                                        reliable = false,
-                                        parallel_keystore = true}}
+                        aae_util:log(
+                            "AAE01", [StoreState, IsEmpty], logs(), LogLevels),
+                        {
+                            ok,
+                            #state{
+                                key_store = Pid, 
+                                next_rebuild = os:timestamp(), 
+                                rebuild_schedule = RebuildSchedule,
+                                reliable = false,
+                                parallel_keystore = true
+                            }
+                        }
                 end;
             {native, StoreType, BackendPid} ->
                 aae_util:log("AAE02", [StoreType], logs(), LogLevels),
                 StoreRP = filename:join([RootPath, StoreType, ?STORE_PATH]),
                 {ok, {LastRebuild, _IsE}, KeyStorePid} =
-                    aae_keystore:store_nativestart(StoreRP, 
-                                                    StoreType, 
-                                                    BackendPid,
-                                                    LogLevels),
+                    aae_keystore:store_nativestart(
+                        StoreRP, StoreType, BackendPid, LogLevels),
                 RebuildTS = 
                     schedule_rebuild(LastRebuild, RebuildSchedule),
-                {ok, #state{key_store = KeyStorePid, 
-                                next_rebuild = RebuildTS, 
-                                rebuild_schedule = RebuildSchedule,
-                                reliable = true,
-                                parallel_keystore = false}}
+                {
+                    ok, 
+                    #state{
+                        key_store = KeyStorePid, 
+                        next_rebuild = RebuildTS, 
+                        rebuild_schedule = RebuildSchedule,
+                        reliable = true,
+                        parallel_keystore = false
+                    }
+                }
         end,
 
     % Start the TreeCaches

--- a/src/aae_keystore.erl
+++ b/src/aae_keystore.erl
@@ -42,19 +42,25 @@
             native/2,
             native/3]).
 
--export([store_parallelstart/3,
-            store_nativestart/4,
-            store_startupdata/1,
-            store_close/1,
-            store_destroy/1,
-            store_mput/3,
-            store_mload/2,
-            store_prompt/2,
-            store_currentstatus/1,
-            store_fold/8,
-            store_fetchclock/3,
-            store_bucketlist/1,
-            store_loglevel/2]).
+-export(
+    [
+        store_generate_backendoptions/0,
+        store_setbackendoption/3,
+        store_parallelstart/4,
+        store_nativestart/4,
+        store_startupdata/1,
+        store_close/1,
+        store_destroy/1,
+        store_mput/3,
+        store_mload/2,
+        store_prompt/2,
+        store_currentstatus/1,
+        store_fold/8,
+        store_fetchclock/3,
+        store_bucketlist/1,
+        store_loglevel/2
+    ]
+).
 
 -export([define_addobjectspec/3,
             define_delobjectspec/3,
@@ -92,15 +98,20 @@
                         key :: binary(),
                         last_mod_dates :: undefined|list(erlang:timestamp()),
                         value = null :: tuple()|null}).
-
--define(LEVELED_BACKEND_OPTS, 
-    [{cache_size, 2000},
-        {sync_strategy, none},
-        {max_journalsize, 100000000},
+                    
+-define(LEVELED_DEFAULTS,
+    [
+        {max_pencillercachesize, 16000},
+        {max_journalobjectcount, 20000},
         {compression_method, native},
-        {compression_point, on_receipt},
         {snapshot_timeout_short, 3600},
-        {snapshot_timeout_long, 172800}]).
+        {snapshot_timeout_long, 172800},
+        {database_id, 65535},
+        {log_level, info},
+        {forced_logs, []},
+        {stats_logfrequency, 60}
+    ]
+).
 -define(CHANGEQ_LOGFREQ, 100000).
 -define(STATE_BUCKET, <<"state">>).
 -define(MANIFEST_FN, "keystore"). 
@@ -129,6 +140,26 @@
 -define(LOAD_PAUSE, 1000). % On backlog when loading a parallel store
 -define(LOAD_BATCH, 256).
 
+-type backend_mpcs() ::
+    {max_pencillercachesize, 2000..32000}.
+-type backend_mjoc() ::
+    {max_journalobjectcount, pos_integer()}.
+-type backend_cm() :: native|zstd.
+-type backend_sto() ::
+    {snapshot_timeout_long|snapshot_timeout_short, pos_integer()}.
+-type backend_lll() ::
+    {log_level, debug|info|warn}.
+-type backend_fls() :: 
+    {forced_logs, list(atom())}.
+-type backend_slf() ::
+    {stats_logfrequency, pos_integer()}.
+-type leveled_options() ::
+    [
+        backend_mpcs()|backend_mjoc()|
+        backend_cm()|
+        backend_sto()|
+        backend_lll()|backend_fls()|backend_slf()
+    ].
 -type bucket() :: binary()|{binary(),binary()}.
 -type key() :: binary().
 -type parallel_stores() :: leveled_so|leveled_ko. 
@@ -191,48 +222,84 @@
     % needs to be calculated (like IndexN in native stores)
 
 
--export_type([parallel_stores/0,
-                native_stores/0,
-                manifest/0,
-                objectspec/0,
-                value_element/0,
-                range_limiter/0,
-                segment_limiter/0,
-                modified_limiter/0,
-                count_limiter/0,
-                rebuild_prompts/0,
-                bucket/0,
-                key/0]).
+-export_type(
+    [
+        leveled_options/0,
+        parallel_stores/0,
+        native_stores/0,
+        manifest/0,
+        objectspec/0,
+        value_element/0,
+        range_limiter/0,
+        segment_limiter/0,
+        modified_limiter/0,
+        count_limiter/0,
+        rebuild_prompts/0,
+        bucket/0,
+        key/0
+    ]
+).
 
 
 %%%============================================================================
 %%% API
 %%%============================================================================
 
+-spec store_generate_backendoptions() -> leveled_options().
+store_generate_backendoptions() ->
+    ?LEVELED_DEFAULTS.
+
+-spec store_setbackendoption(
+    atom(), any(), leveled_options()) -> leveled_options().
+store_setbackendoption(max_pencillercachesize, MPCS, LeveledOpts)
+        when is_integer(MPCS), MPCS =< 32000, MPCS >= 2000 ->
+    lists:ukeysort(1, [{max_pencillercachesize, MPCS}|LeveledOpts]);
+store_setbackendoption(max_journalobjectcount, MJOC, LeveledOpts)
+        when is_integer(MJOC), MJOC > 0 ->
+    lists:ukeysort(1, [{max_journalobjectcount, MJOC}|LeveledOpts]);
+store_setbackendoption(compression_method, CM, LeveledOpts)
+        when CM == native; CM == zstd; CM == lz4 ->
+    lists:ukeysort(1, [{compression_method, CM}|LeveledOpts]);
+store_setbackendoption(snapshot_timeout_short, STS, LeveledOpts)
+        when is_integer(STS), STS > 0 ->
+    lists:ukeysort(1, [{snapshot_timeout_short, STS}|LeveledOpts]);
+store_setbackendoption(snapshot_timeout_long, STL, LeveledOpts)
+        when is_integer(STL), STL > 0 ->
+    lists:ukeysort(1, [{snapshot_timeout_long, STL}|LeveledOpts]);
+store_setbackendoption(database_id, DID, LeveledOpts)
+        when is_integer(DID), DID >= 0 ->
+    lists:ukeysort(1, [{database_id, DID}|LeveledOpts]);
+store_setbackendoption(log_level, LLL, LeveledOpts)
+        when LLL == debug; LLL == info; LLL == warn ->
+    lists:ukeysort(1, [{log_level, LLL}|LeveledOpts]);
+store_setbackendoption(forced_logs, FLS, LeveledOpts)
+        when is_list(FLS) ->
+    lists:ukeysort(1, [{forced_logs, FLS}|LeveledOpts]);
+store_setbackendoption(stats_logfrequency, SLF, LeveledOpts)
+        when is_integer(SLF), SLF > 0 ->
+    lists:ukeysort(1, [{stats_logfrequency, SLF}|LeveledOpts]).
+
 -spec store_parallelstart(
-    list(), parallel_stores(), aae_util:log_levels()|undefined) ->
+    list(),
+    parallel_stores(),
+    aae_util:log_levels()|undefined,
+    leveled_options()) ->
         {ok, {erlang:timestamp()|never, boolean()}, pid()}.
 %% @doc
 %% Start a store to be run in parallel mode
-store_parallelstart(Path, leveled_so, LogLevels) ->
-    MinLevel = aae_util:min_loglevel(LogLevels),
-    AddOpts = [{max_pencillercachesize, 8000}, {log_level, MinLevel}],
+store_parallelstart(Path, leveled_so, LogLevels, LeveledOpts) ->
     Opts = 
         [{root_path, Path}, 
             {native, {false, leveled_so}}, 
-            {backend_opts,
-                lists:ukeysort(1, AddOpts ++ ?LEVELED_BACKEND_OPTS)},
+            {backend_opts, LeveledOpts},
             {log_levels, LogLevels}],
     {ok, Pid} = gen_fsm:start_link(?MODULE, [Opts], []),
     store_startupdata(Pid);
-store_parallelstart(Path, leveled_ko, LogLevels) ->
-    MinLevel = aae_util:min_loglevel(LogLevels),
-    AddOpts = [{max_pencillercachesize, 32000}, {log_level, MinLevel}],
+store_parallelstart(Path, leveled_ko, LogLevels, LeveledOpts) ->
     Opts = 
         [{root_path, Path}, 
             {native, {false, leveled_ko}}, 
-            {backend_opts, 
-                lists:ukeysort(1, AddOpts ++ ?LEVELED_BACKEND_OPTS)},
+            {backend_opts, LeveledOpts},
             {log_levels, LogLevels}],
     {ok, Pid} = gen_fsm:start_link(?MODULE, [Opts], []),
     store_startupdata(Pid).
@@ -621,12 +688,9 @@ handle_sync_event(ping, _From, StateName, State) ->
     {reply, pong, StateName, State}.
 
 handle_event({log_level, LogLevels}, StateName, State) ->
-    MinLevel = aae_util:min_loglevel(LogLevels),
-    BackendOpts = [{log_level, MinLevel}|?LEVELED_BACKEND_OPTS],
-        % Change of log level will take place after next store is started
     {next_state,
         StateName,
-        State#state{log_levels = LogLevels, backend_opts = BackendOpts}}.
+        State#state{log_levels = LogLevels}}.
 
 handle_info(_Msg, StateName, State) ->
     {next_state, StateName, State}.
@@ -1300,7 +1364,7 @@ empty_buildandclose_tester(StoreType) ->
     RootPath = "test/keystore0/",
     aae_util:clean_subdir(RootPath),
     {ok, {never, true}, Store0} =
-        store_parallelstart(RootPath, StoreType, undefined),
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     
     {ok, Manifest0} = open_manifest(RootPath, undefined),
     {parallel, CurrentGUID} = store_currentstatus(Store0),
@@ -1312,7 +1376,7 @@ empty_buildandclose_tester(StoreType) ->
     ?assertMatch(CurrentGUID, Manifest1#manifest.current_guid),
     
     {ok, {never, true}, Store1} =
-        store_parallelstart(RootPath, StoreType, undefined),
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     ?assertMatch({parallel, CurrentGUID}, store_currentstatus(Store1)),
     ok = store_close(Store1),
     
@@ -1386,7 +1450,7 @@ load_tester(StoreType) ->
     {L4, L5} = lists:split(32, R3),
 
     {ok, {never, true}, Store0} =
-        store_parallelstart(RootPath, StoreType, undefined),
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     ok = store_mput(Store0, L1, false),
     ok = store_mput(Store0, L2, false),
     ok = store_mput(Store0, L3, false),
@@ -1453,8 +1517,8 @@ load_tester(StoreType) ->
 
     ok = store_close(Store0),
 
-    {ok, {LastRebuildTime, false}, Store1} 
-        = store_parallelstart(RootPath, StoreType, undefined),
+    {ok, {LastRebuildTime, false}, Store1} =
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     
     ?assertMatch(true, LastRebuildTime > RebuildCompleteTime),
    
@@ -1552,7 +1616,7 @@ load2_tester(StoreType) ->
         lists:foldl(SplitFun, {[], ObjectSpecs}, lists:seq(1, 41)),
     
     {ok, {never, true}, Store0} =
-        store_parallelstart(RootPath, StoreType, undefined),
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     
     lists:foreach(fun(B) -> store_mput(Store0, B, false) end,
                     lists:reverse(BatchList0)),
@@ -1670,10 +1734,13 @@ fetch_clock_test() ->
     Spc3 = define_addobjectspec(<<"B2">>, <<"K1">>, GenVal([{"c", 1}])),
     Spc4 = define_addobjectspec(<<"B1">>, <<"K1">>, GenVal([{"d", 1}])),
 
-    {ok, Store0} = open_store(leveled_so, 
-                                ?LEVELED_BACKEND_OPTS, 
-                                RootPath,
-                                leveled_util:generate_uuid()),
+    {ok, Store0} =
+        open_store(
+            leveled_so,
+            ?LEVELED_DEFAULTS,
+            RootPath,
+            leveled_util:generate_uuid()
+        ),
 
     do_load(leveled_so, Store0, [Spc1, Spc2, Spc3, Spc4]),
 
@@ -1711,7 +1778,7 @@ big_load_tester(StoreType) ->
     GenerateKeyFun = aae_util:test_key_generator(v1),
 
     {ok, {never, true}, Store0} =
-        store_parallelstart(RootPath, StoreType, undefined),
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
 
     InitialKeys = 
         lists:map(GenerateKeyFun, lists:seq(1, KeyCount)),
@@ -1742,8 +1809,8 @@ big_load_tester(StoreType) ->
 
     ok = store_close(Store0),
 
-    {ok, {RebuildTS, false}, Store1} 
-        = store_parallelstart(RootPath, StoreType, undefined),
+    {ok, {RebuildTS, false}, Store1} =
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     ?assertMatch(true, RebuildTS < os:timestamp()),
     
     timed_fold(Store1, KeyCount, FoldObjectsFun, StoreType, true),
@@ -1768,8 +1835,8 @@ big_load_tester(StoreType) ->
     M0 = clear_pendingpath(PendingManifest, RootPath),
     ?assertMatch(undefined, M0#manifest.pending_guid),
 
-    {ok, {RebuildTS2, false}, Store2} 
-        = store_parallelstart(RootPath, StoreType, undefined),
+    {ok, {RebuildTS2, false}, Store2} =
+        store_parallelstart(RootPath, StoreType, undefined, ?LEVELED_DEFAULTS),
     ?assertMatch(RebuildTS, RebuildTS2),
 
     timed_fold(Store2, KeyCount, FoldObjectsFun, StoreType, true),

--- a/src/aae_util.erl
+++ b/src/aae_util.erl
@@ -14,7 +14,6 @@
             get_opt/2,
             get_opt/3,
             make_binarykey/2,
-            min_loglevel/1,
             safe_open/1]).
 
 -export([clean_subdir/1,
@@ -128,14 +127,6 @@ make_binarykey({Type, Bucket}, Key)
     <<Type/binary, Bucket/binary, Key/binary>>;
 make_binarykey(Bucket, Key) when is_binary(Bucket), is_binary(Key) ->
     <<Bucket/binary, Key/binary>>.
-
--spec min_loglevel(log_levels()|undefined) -> log_level().
-%% @doc
-%% Return the lowest log level to be used in leveled startup
-min_loglevel(undefined) ->
-    info;
-min_loglevel([MinLevel|_Rest]) ->
-    MinLevel.
 
 %%%============================================================================
 %%% Internal functions


### PR DESCRIPTION
Not implemented the full set of options, just a few obviously relevant ones.

Will require a change in riak_kv_vnode to allow for the config to be passed through.