### PR TITLE
Handle VCs that hash to 0

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [22, 24]
+        otp: [24]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -4,24 +4,30 @@ on:
   push:
     branches:
     - develop-3.1
-    - develop-3.0
   pull_request:
     branches:
     - develop-3.1
-    - develop-3.0
 
 jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.os }} with OTP ${{ matrix.otp }}
+    runs-on: ${{ matrix.os }}
 
-    container:
-      image: erlang:22.3.3
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: [22, 24]
+        os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Install Erlang/OTP
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
     - name: Compile
-      run: rebar3 compile
+      run: ./rebar3 compile
     - name: Run tests
-      run: rebar3 do xref, dialyzer, eunit, ct
+      run: ./rebar3 do xref, dialyzer, eunit, ct

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KV Tictac Tree
 
-[![Build Status](https://github.com/martinsumner/kv_index_tictactree/actions/workflows/erlang.yml/badge.svg?branch=develop-3.0)](https://github.com/martinsumner/kv_index_tictactree/actions)
+[![Build Status](https://github.com/martinsumner/kv_index_tictactree/actions/workflows/erlang.yml/badge.svg?branch=develop-3.1)](https://github.com/martinsumner/kv_index_tictactree/actions)
 
 An Active Anti-Entropy library for Key-Value stores in Erlang.
 

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -126,7 +126,7 @@
         % scheduled by adding a random integer number of seconds (between 0 
         % and the jitter value) to the minimum time
 -type version_vector()
-        :: list(tuple())|none|undefined.
+        :: list(tuple())|none.
         % The version vector is normally a list of tuples.  The vector could 
         % be none if this is a put of a new item (when the previous vector 
         % would be none), or a deletion of an existing item (when the current
@@ -149,6 +149,11 @@
 -type fold_objects_fun()
         :: fun((aae_keystore:bucket(), aae_keystore:key(), term(), list())
                     -> list()).
+-type clock_hash() :: integer()|none.
+        % Hash of the clock which is either an integer 1..(2^32 - 1) or none
+        % to represent there was no clock to hash.  The hash of the clock part
+        % impacts only 27-bits, but may be combined with a hash of the key,
+        % where that has is 0..(2^32 - 1) 
 
 -export_type([responsible_preflist/0,
                 keystore_type/0,
@@ -210,17 +215,19 @@ aae_start(
 aae_nextrebuild(Pid) ->
     gen_server:call(Pid, rebuild_time, ?SYNC_TIMEOUT).
 
--spec aae_put(pid(), responsible_preflist(), 
-                            aae_keystore:bucket(), aae_keystore:key(),
-                            version_vector(), version_vector(),
-                            binary()) -> ok.
+-spec aae_put(
+    pid(),
+    responsible_preflist(), 
+    aae_keystore:bucket(),
+    aae_keystore:key(),
+    version_vector(), version_vector()|undefined,
+    binary()) -> ok.
 %% @doc
 %% Put a change into the AAE system - updating the TicTac tree, and the 
 %% KeyStore where a parallel Keystore is used.
 aae_put(Pid, IndexN, Bucket, Key, CurrentVV, PrevVV, BinaryObj) ->
-    gen_server:cast(Pid, 
-                    {put, IndexN, Bucket, Key, CurrentVV, PrevVV, BinaryObj}).
-
+    gen_server:cast(
+        Pid, {put, IndexN, Bucket, Key, CurrentVV, PrevVV, BinaryObj}).
 
 -spec aae_fetchroot(pid(), list(responsible_preflist()), returner()) -> ok.
 %% @doc
@@ -1315,7 +1322,7 @@ handle_unexpected_key(Bucket, Key, IndexN, TreeCaches, LogLevels) ->
                     logs(), LogLevels).
 
 -spec hash_clocks(
-    version_vector(), version_vector()) -> {integer()|none, integer()|none}.
+    version_vector(), version_vector()) -> {clock_hash(), clock_hash()}.
 %% @doc
 %% Hash the version vectors, if there is one 
 hash_clocks(CurrentVV, PrevVV) ->

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -1314,20 +1314,20 @@ handle_unexpected_key(Bucket, Key, IndexN, TreeCaches, LogLevels) ->
     aae_util:log("AAE03", [Bucket, Key, IndexN, RespPreflists],
                     logs(), LogLevels).
 
--spec hash_clocks(version_vector(), version_vector()) 
-                                                    -> {integer(), integer()}.
+-spec hash_clocks(
+    version_vector(), version_vector()) -> {integer()|none, integer()|none}.
 %% @doc
-%% Has the version vectors 
+%% Hash the version vectors, if there is one 
 hash_clocks(CurrentVV, PrevVV) ->
     {hash_clock(CurrentVV), hash_clock(PrevVV)}.
 
 hash_clock(none) ->
-    0;
+    none;
 hash_clock(Clock) ->
     erlang:phash2(lists:sort(Clock)).
 
--spec wait_on_sync(atom(), atom(), pid(), tuple()|atom(), pos_integer())
-                                                                    -> any().
+-spec wait_on_sync(
+    atom(), atom(), pid(), tuple()|atom(), pos_integer()) -> any().
 %% @doc
 %% Wait on a sync call until timeout - but don't crash on the timeout
 wait_on_sync(Mod, Fun, Pid, Call, Timeout) ->
@@ -1349,7 +1349,6 @@ preflist_wrapper_fun(FoldObjectsFun, IndexNs) ->
                 Acc
         end
     end.
-
 
 %%%============================================================================
 %%% log definitions

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -219,7 +219,7 @@ handle_cast({alter, Key, CurrentHash, OldHash}, State) ->
             State#state.tree,
             Key,
             {CurrentHash, OldHash},
-            fun binary_extractfun/2,
+            fun alterhash_fun/2,
             true
         ),
     State0 = 
@@ -255,7 +255,7 @@ handle_cast({complete_load, Tree}, State=#state{loading=Loading})
     LoadFun = 
         fun({Key, CH, OH}, AccTree) ->
             leveled_tictac:add_kv(
-                AccTree, Key, {CH, OH}, fun binary_extractfun/2)
+                AccTree, Key, {CH, OH}, fun alterhash_fun/2)
         end,
     Tree0 = lists:foldr(LoadFun, Tree, State#state.change_queue),
     aae_util:log("C0008",
@@ -417,16 +417,26 @@ form_cache_filename(RootPath, SaveSQN) ->
     filename:join(RootPath, integer_to_list(SaveSQN) ++ ?FINAL_EXT).
 
 
--spec binary_extractfun(
+-spec alterhash_fun(
     binary(),
     {integer()|none, integer()|none}) -> {binary(), {is_hash, integer()}}.
 %% @doc 
 %% Function to calculate the hash change need to make an alter into a straight
 %% add as the BinExtractfun in leveled_tictac
-binary_extractfun(Key, {CurrentHash, OldHash}) ->
+alterhash_fun(Key, {CurrentHash, OldHash}) ->
     % TODO: Should move this function to leveled_tictac
     % - requires secret knowledge of implementation to perform
     % alter
+    % 
+    % What we know about the addition of a value into a leveled_tictac tree is
+    % that an addition is made be doing:
+    % SegHash bxor (AltKeyHash bxor ClockHash)
+    % 
+    % The ClockHash in this case is the output of this function.  When an
+    % alteration is being made the resulting Hash needs to still include the
+    % AltKeyHash, so it is necessary apply bxor AltKeyHash an odd number of
+    % times.  Hence an alteration or a null change must include the AltKeyHash
+    % within the ClockHash
     UpdateHash = 
         case {CurrentHash, OldHash} of
             {none, OldHash} when is_integer(OldHash) ->
@@ -442,16 +452,16 @@ binary_extractfun(Key, {CurrentHash, OldHash}) ->
                 % In this case a neutral update is required (when bxor'd with
                 % the key hash it should produce no change) - so return the
                 % relevant hash of the key
-                {_SegmentHash, AltHash}
+                {_SegmentHash, AltKeyHash}
                     = leveled_tictac:keyto_doublesegment32(Key),
-                AltHash;
+                AltKeyHash;
             {CurrentHash, OldHash}
                     when is_integer(CurrentHash), is_integer(OldHash) ->
                 % Alter - need to account for hashing with key
                 % to remove the original
-                {_SegmentHash, AltHash}
+                {_SegmentHash, AltKeyHash}
                     = leveled_tictac:keyto_doublesegment32(Key),
-                CurrentHash bxor (OldHash bxor AltHash)
+                CurrentHash bxor (OldHash bxor AltKeyHash)
         end,
     {Key, {is_hash, UpdateHash}}.
 

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -91,7 +91,7 @@ cache_destroy(AAECache) ->
 cache_close(AAECache) ->
     gen_server:call(AAECache, close, ?SYNC_TIMEOUT).
 
--spec cache_alter(pid(), binary(), integer(), integer()) -> ok.
+-spec cache_alter(pid(), binary(), integer()|none, integer()|none) -> ok.
 %% @doc
 %% Change the hash tree to reflect an addition and removal of a hash value
 cache_alter(AAECache, Key, CurrentHash, OldHash) -> 
@@ -417,33 +417,35 @@ form_cache_filename(RootPath, SaveSQN) ->
     filename:join(RootPath, integer_to_list(SaveSQN) ++ ?FINAL_EXT).
 
 
--spec binary_extractfun(binary(), {integer(), integer()}) -> 
-                                            {binary(), {is_hash, integer()}}.
+-spec binary_extractfun(
+    binary(),
+    {integer()|none, integer()|none}) -> {binary(), {is_hash, integer()}}.
 %% @doc 
-%% Function to calulate the hash change need to make an alter into a straight
+%% Function to calculate the hash change need to make an alter into a straight
 %% add as the BinExtractfun in leveled_tictac
 binary_extractfun(Key, {CurrentHash, OldHash}) ->
     % TODO: Should move this function to leveled_tictac
     % - requires secret knowledge of implementation to perform
     % alter
-    RemoveH = 
+    UpdateHash = 
         case {CurrentHash, OldHash} of 
-            {0, _} ->
+            {none, OldHash} when is_integer(OldHash) ->
                 % Remove - treat like adding back in
                 % the tictac will bxor this with the key - so don't need to
                 % bxor this here again
                 OldHash;
-            {_, 0} ->
-                % Add 
-                0;
-            _ ->
+            {CurrentHash, none} when is_integer(CurrentHash) ->
+                % Nothing to remove - straight add
+                CurrentHash;
+            {CurrentHash, OldHash}
+                    when is_integer(CurrentHash), is_integer(OldHash) ->
                 % Alter - need to account for hashing with key
                 % to remove the original
                 {_SegmentHash, AltHash}
                     = leveled_tictac:keyto_doublesegment32(Key),
-                OldHash bxor AltHash
+                CurrentHash bxor (OldHash bxor AltHash)
         end,
-    {Key, {is_hash, CurrentHash bxor RemoveH}}.
+    {Key, {is_hash, UpdateHash}}.
 
 %%%============================================================================
 %%% log definitions
@@ -526,7 +528,7 @@ dirty_saveopen_test() ->
     RP0 = filename:join(RootPath, integer_to_list(1)) ++ "/",
     {ok, Cpid0} = cache_new(RootPath, 1, undefined),
     Hash0 = erlang:phash2({<<"K1">>, <<"C1">>}),
-    cache_alter(Cpid0, <<"K1">>, Hash0, 0),
+    cache_alter(Cpid0, <<"K1">>, Hash0, none),
     ok = cache_close(Cpid0),
     ?assertMatch(true, filelib:is_file(form_cache_filename(RP0, 1))),
     {true, Cpid1} = cache_open(RootPath, 1, undefined),
@@ -552,7 +554,7 @@ dirty_saveopen_test() ->
     ?assertMatch(false, filelib:is_file(form_cache_filename(RP0, 4))),
     {false, Cpid4} = cache_open(RootPath, 1, undefined),
     cache_startload(Cpid4),
-    cache_alter(Cpid4, <<"K1">>, Hash3, 0),
+    cache_alter(Cpid4, <<"K1">>, Hash3, none),
     T0 = leveled_tictac:new_tree(raw, ?TREE_SIZE),
     cache_completeload(Cpid4, T0),
     ok = cache_close(Cpid4),
@@ -656,7 +658,6 @@ simple_test() ->
     Root = cache_root(AAECache1),
     ?assertMatch(Root, CompareRoot),
 
-
     ok = cache_destroy(AAECache1).
 
 
@@ -685,16 +686,15 @@ replace_test() ->
     KHL0 = lists:sublist(InitialKeys, 60) ++ AlternateKeys,
     DirectAddFun =
         fun({K, H}, TreeAcc) ->
-            leveled_tictac:add_kv(TreeAcc, 
-                                    K, H, 
-                                    fun(Key, Value) -> 
-                                        {Key, {is_hash, Value}} 
-                                    end)
+            leveled_tictac:add_kv(
+                TreeAcc, 
+                K, H, 
+                fun(Key, Value) ->  {Key, {is_hash, Value}} end
+            )
         end,
     CompareTree = 
-        lists:foldl(DirectAddFun, 
-                        leveled_tictac:new_tree(raw, ?TREE_SIZE), 
-                        KHL0),
+        lists:foldl(
+            DirectAddFun, leveled_tictac:new_tree(raw, ?TREE_SIZE), KHL0),
     
     %% The load tree is a tree as would have been produced by a fold over a 
     %% snapshot taken at the time all the initial keys added.
@@ -714,6 +714,21 @@ replace_test() ->
     Root = cache_root(AAECache0),
     ?assertMatch(Root, CompareRoot),
 
+    cache_alter(AAECache0, <<"K_With0Hash">>, 0, none),
+        % Key added with a Vclock  that hashes to 0
+    cache_alter(AAECache0, <<"K_With0Hash">>, (1 bsl 27) - 1, 0),
+        % Key now has a Vclock that hashes to 2 ^ 27 -1 (the top of the hash range)
+    CompareTree1 = DirectAddFun({<<"K_With0Hash">>, (1 bsl 27) - 1}, CompareTree),
+    AlterRoot = cache_root(AAECache0),
+    AlterComapreRoot = leveled_tictac:fetch_root(CompareTree1),
+    % Altering a key which had a hash of 0 has the same impact as inserting from scratch 
+    ?assertMatch(AlterRoot, AlterComapreRoot),
+
+    cache_alter(AAECache0, <<"K_With0Hash">>, none, (1 bsl 27) - 1),
+
+    % Removing the key => as if it was never there
+    NewRoot = cache_root(AAECache0),
+    ?assertMatch(Root, NewRoot),
 
     ok = cache_destroy(AAECache0).
 
@@ -736,7 +751,7 @@ dirty_segment_test() ->
         fun(I) ->
             K = integer_to_binary(I),
             H = erlang:phash2(leveled_rand:uniform(100000)),
-            cache_alter(AAECache0, K, H, 0)
+            cache_alter(AAECache0, K, H, none)
         end,
 
     lists:foreach(AddFun, lists:seq(2350000, 2380000)),
@@ -761,7 +776,7 @@ dirty_segment_test() ->
     {_HK1, TTH1} = leveled_tictac:tictac_hash(K1, {is_hash, H1}),
     {_HK2, TTH2} = leveled_tictac:tictac_hash(K2, {is_hash, H2}),
 
-    cache_alter(AAECache0, K1, H1, 0),
+    cache_alter(AAECache0, K1, H1, none),
 
     Leaf1 = get_leaf(AAECache0, BranchID, LeafID),
     ?assertMatch(Leaf1, Leaf0 bxor TTH1),
@@ -780,7 +795,7 @@ dirty_segment_test() ->
 
     GUID1 = leveled_util:generate_uuid(),
     cache_markdirtysegments(AAECache0, [S0], GUID1),
-    cache_alter(AAECache0, K2, H2, 0),
+    cache_alter(AAECache0, K2, H2, none),
     Leaf2 = get_leaf(AAECache0, BranchID, LeafID),
     ?assertMatch(Leaf2, Leaf0 bxor TTH2),
     cache_replacedirtysegments(AAECache0, [{S0, Leaf0}], GUID1),
@@ -816,7 +831,7 @@ test_setup_funs(InitialKeys) ->
     AddFun = 
         fun(CachePid) ->
             fun({K, H}) ->
-                cache_alter(CachePid, K, H, 0)
+                cache_alter(CachePid, K, H, none)
             end
         end,
     AlterFun =
@@ -830,7 +845,7 @@ test_setup_funs(InitialKeys) ->
         fun(CachePid) ->
             fun({K, _H}) ->
                 {K, OH} = lists:keyfind(K, 1, InitialKeys),
-                cache_alter(CachePid, K, 0, OH)
+                cache_alter(CachePid, K, none, OH)
             end
         end,
     {AddFun, AlterFun, RemoveFun}.

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -439,8 +439,9 @@ binary_extractfun(Key, {CurrentHash, OldHash}) ->
                 CurrentHash;
             {none, none} ->
                 % This may be prompted in rehash.
-                % In this case ant to produce a neutral update (when bxor'd
-                % with the key hash) - so return the relevant hash of the key
+                % In this case a neutral update is required (when bxor'd with
+                % the key hash it should produce no change) - so return the
+                % relevant hash of the key
                 {_SegmentHash, AltHash}
                     = leveled_tictac:keyto_doublesegment32(Key),
                 AltHash;

--- a/src/aae_treecache.erl
+++ b/src/aae_treecache.erl
@@ -428,7 +428,7 @@ binary_extractfun(Key, {CurrentHash, OldHash}) ->
     % - requires secret knowledge of implementation to perform
     % alter
     UpdateHash = 
-        case {CurrentHash, OldHash} of 
+        case {CurrentHash, OldHash} of
             {none, OldHash} when is_integer(OldHash) ->
                 % Remove - treat like adding back in
                 % the tictac will bxor this with the key - so don't need to
@@ -437,6 +437,13 @@ binary_extractfun(Key, {CurrentHash, OldHash}) ->
             {CurrentHash, none} when is_integer(CurrentHash) ->
                 % Nothing to remove - straight add
                 CurrentHash;
+            {none, none} ->
+                % This may be prompted in rehash.
+                % In this case ant to produce a neutral update (when bxor'd
+                % with the key hash) - so return the relevant hash of the key
+                {_SegmentHash, AltHash}
+                    = leveled_tictac:keyto_doublesegment32(Key),
+                AltHash;
             {CurrentHash, OldHash}
                     when is_integer(CurrentHash), is_integer(OldHash) ->
                 % Alter - need to account for hashing with key
@@ -729,6 +736,13 @@ replace_test() ->
     % Removing the key => as if it was never there
     NewRoot = cache_root(AAECache0),
     ?assertMatch(Root, NewRoot),
+
+    cache_alter(AAECache0, <<"K_WithNeutralChange">>, 1, none),
+    cache_alter(AAECache0, <<"K_WithNeutralChange">>, none, none),
+    cache_alter(AAECache0, <<"K_WithNeutralChange">>, none, 1),
+
+    UnchangedRoot = cache_root(AAECache0),
+    ?assertMatch(Root, UnchangedRoot),
 
     ok = cache_destroy(AAECache0).
 


### PR DESCRIPTION
Because of a mistake (perhaps because phash/1 hashed to a range starting at 1, and phash2/1 now starts at 0) - special meaning was attributed to a hash of 0, which would means that updating hashtrees would not be handled correctly if the actual clock had a hash collision with 0.

Special meaning now uses `none` not 0 - and 0 is handled as with any other hash value.