### PR TITLE
Mas d34 orkv.i42 cache filter

### DIFF
--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -28,12 +28,14 @@
     aae_start/6,
     aae_start/7,
     aae_start/8,
+    aae_start/9,
     aae_nextrebuild/1,
     aae_set_rebuild_schedule/2,
     aae_get_rebuild_schedule/1,
     aae_prompt_nextrebuild/2,
     aae_get_object_splitfun/1,
     aae_set_object_splitfun/2,
+    aae_reset_key_filter/1,
     aae_put/7,
     aae_close/1,
     aae_destroy/1,
@@ -57,7 +59,6 @@
 ]).
 
 -export([
-    foldobjects_buildtrees/2,
     hash_clocks/2,
     wrapped_splitobjfun/1
 ]).
@@ -96,7 +97,8 @@
     log_levels :: aae_util:log_levels(),
     runner_queue = [] :: list(runner_work()),
     queue_backlog = false :: boolean(),
-    block_next_put = false :: boolean()
+    block_next_put = false :: boolean(),
+    key_filter = none :: key_filter_fun()
 }).
 
 -record(options, {
@@ -107,7 +109,8 @@
     object_splitfun,
     root_path :: list(),
     log_levels :: aae_util:log_levels(),
-    leveled_options :: aae_keystore:leveled_options()
+    leveled_options :: aae_keystore:leveled_options(),
+    key_filter = none :: key_filter_fun()
 }).
 
 -define(IS_DEF(Term), Term =/= undefined).
@@ -162,6 +165,9 @@
             binary()
         }
     ).
+-type key_filter_fun() ::
+    none |
+    fun(({aae_keystore:bucket(), aae_keystore:key()}|reset) -> boolean()).
 %% erlfmt:ignore-end
 
 -type clock_hash() :: integer() | none.
@@ -176,7 +182,8 @@
     rebuild_schedule/0,
     version_vector/0,
     clock_hash/0,
-    runner_work/0
+    runner_work/0,
+    key_filter_fun/0
 ]).
 
 %%%============================================================================
@@ -194,6 +201,21 @@ aae_start(KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels) ->
         KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels, LeveledOpts
     ).
 
+aae_start(
+    KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels, LeveledOpts
+) ->
+    aae_start(
+        KeyStoreT,
+        IsEmpty,
+        RS,
+        PLs,
+        Path,
+        ObjSplitFun,
+        LogLevels,
+        LeveledOpts,
+        none
+    ).
+
 -spec aae_start(
     keystore_type(),
     boolean(),
@@ -202,7 +224,8 @@ aae_start(KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels) ->
     list(),
     fun((term()) -> tuple()),
     aae_util:log_levels() | undefined,
-    aae_keystore:leveled_options()
+    aae_keystore:leveled_options(),
+    key_filter_fun()
 ) -> {ok, pid()}.
 %% @doc
 %% Start an AAE controller
@@ -210,7 +233,7 @@ aae_start(KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels) ->
 %% {Size, SibCount, IndexHash, LMD, MD}.  If the SplitFun previously outputted
 %% {Size, SibCount, IndexHash, null} that output will be converted
 aae_start(
-    KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels, LeveledOpts
+    KeyStoreT, IsEmpty, RS, PLs, Path, ObjSplitFun, LogLevels, LeveledOpts, KFF
 ) ->
     WrapObjSplitFun = wrapped_splitobjfun(ObjSplitFun),
     AAEopts =
@@ -222,7 +245,8 @@ aae_start(
             root_path = Path,
             object_splitfun = WrapObjSplitFun,
             log_levels = LogLevels,
-            leveled_options = LeveledOpts
+            leveled_options = LeveledOpts,
+            key_filter = KFF
         },
     {ok, Pid} = gen_server:start(?MODULE, [AAEopts], []),
     {ok, Pid}.
@@ -263,6 +287,12 @@ aae_get_object_splitfun(Pid) ->
 %% with a different value of 'storeheads'.
 aae_set_object_splitfun(Pid, A) ->
     gen_server:call(Pid, {set_object_splitfun, A}, ?SYNC_TIMEOUT).
+
+-spec aae_reset_key_filter(pid()) -> boolean().
+%% @doc
+%% Reset the key filter fun (e.g. to clear cache due to a bucket type change)
+aae_reset_key_filter(Pid) ->
+    gen_server:call(Pid, reset_key_filter, ?SYNC_TIMEOUT).
 
 -spec aae_put(
     pid(),
@@ -687,6 +717,7 @@ init([Opts]) ->
     ),
     {ok, State0#state{
         object_splitfun = Opts#options.object_splitfun,
+        key_filter = Opts#options.key_filter,
         index_ns = Opts#options.index_ns,
         tree_caches = TreeCaches,
         broken_trees = not AllTreesOK,
@@ -704,6 +735,8 @@ handle_call(get_object_splitfun, _From, State = #state{object_splitfun = A}) ->
     {reply, A, State};
 handle_call({set_object_splitfun, A}, _From, State) ->
     {reply, ok, State#state{object_splitfun = A}};
+handle_call(reset_key_filter, _From, State) ->
+    {reply, aae_util:apply_key_filter(State#state.key_filter, reset), State};
 handle_call({prompt_nextrebuild, SecsFromNow}, _From, State) ->
     {Mega, Sec, Micros} = os:timestamp(),
     {reply, ok, State#state{next_rebuild = {Mega, Sec + SecsFromNow, Micros}}};
@@ -755,7 +788,9 @@ handle_call({rebuild_trees, IndexNs, PreflistFun, OnlyIfBroken}, _From, State) -
 
                     % Setup a fold over the store
                     {FoldFun, InitAcc} =
-                        foldobjects_buildtrees(IndexNs, LogLevels),
+                        foldobjects_buildtrees(
+                            IndexNs, LogLevels, State#state.key_filter
+                        ),
                     CheckPresence = (StateName == native) and not OnlyIfBroken,
                     % If performing a scheduled rebuild on a native store
                     % then the fold needs to check for the presence of the key
@@ -987,6 +1022,8 @@ handle_call(
         InitMap
     ),
 
+    KFF = State#state.key_filter,
+
     FoldObjFun =
         fun(B, K, V, {Acc, SubTreeAcc}) ->
             {clock, VC} = lists:keyfind(clock, 1, V),
@@ -995,12 +1032,21 @@ handle_call(
             {preflist, PL} = lists:keyfind(preflist, 1, V),
             {PL, T, SegMap} = lists:keyfind(PL, 1, SubTreeAcc),
             {SegID, HashAcc} = lists:keyfind(SegID, 1, SegMap),
-            BinK = aae_util:make_binarykey(B, K),
-            {_, HashToAdd} = leveled_tictac:tictac_hash(BinK, {is_hash, H}),
-            UpdHash = HashAcc bxor HashToAdd,
-            SegMap0 = lists:keyreplace(SegID, 1, SegMap, {SegID, UpdHash}),
             SubTreeAcc0 =
-                lists:keyreplace(PL, 1, SubTreeAcc, {PL, T, SegMap0}),
+                case aae_util:apply_key_filter(KFF, {B, K}) of
+                    true ->
+                        BinK = aae_util:make_binarykey(B, K),
+                        {_, HashToAdd} =
+                            leveled_tictac:tictac_hash(BinK, {is_hash, H}),
+                        UpdHash = HashAcc bxor HashToAdd,
+                        SegMap0 =
+                            lists:keyreplace(
+                                SegID, 1, SegMap, {SegID, UpdHash}
+                            ),
+                        lists:keyreplace(PL, 1, SubTreeAcc, {PL, T, SegMap0});
+                    false ->
+                        SubTreeAcc
+                end,
             {[{B, K, VC} | Acc], SubTreeAcc0}
         end,
     WrappedFoldObjFun = preflist_wrapper_fun(FoldObjFun, IndexNs),
@@ -1165,6 +1211,7 @@ handle_call({ping, RequestTime}, _From, State) ->
 handle_cast({put, IndexN, Bucket, Key, Clock, PrevClock, BinaryObj}, State) ->
     % Setup
     TreeCaches = State#state.tree_caches,
+    KFF = State#state.key_filter,
     BinaryKey = aae_util:make_binarykey(Bucket, Key),
     PrevClock0 =
         case PrevClock of
@@ -1190,21 +1237,26 @@ handle_cast({put, IndexN, Bucket, Key, Clock, PrevClock, BinaryObj}, State) ->
     % Update the TreeCache associated with the Key (should a cache exist for
     % that store)
     State0 =
-        case lists:keyfind(IndexN, 1, TreeCaches) of
-            false ->
+        case
+            {
+                lists:keyfind(IndexN, 1, TreeCaches),
+                aae_util:apply_key_filter(KFF, {Bucket, Key})
+            }
+        of
+            {false, _} ->
                 % Note that this will eventually end up in the Tree Cache if in
                 % the future the IndexN combination is added to the list of
                 % responsible preflists
                 handle_unexpected_key(
-                    Bucket,
-                    Key,
-                    IndexN,
-                    TreeCaches,
-                    State#state.log_levels
+                    Bucket, Key, IndexN, TreeCaches, State#state.log_levels
                 ),
                 State#state{next_rebuild = os:timestamp()};
-            {IndexN, TreeCache} ->
+            {{IndexN, TreeCache}, true} ->
                 ok = aae_treecache:cache_alter(TreeCache, BinaryKey, CH, OH),
+                State;
+            {_, false} ->
+                % i.e. the key is in a bucket that is to be excluded from the
+                % tree cache
                 State
         end,
 
@@ -1316,13 +1368,13 @@ code_change(_OldVsn, State, _Extra) ->
 %%%============================================================================
 
 -spec foldobjects_buildtrees(
-    list(responsible_preflist()), aae_util:log_levels()
+    list(responsible_preflist()), aae_util:log_levels(), key_filter_fun()
 ) ->
     {aae_keystore:fold_fun(), list()}.
 %% @doc
 %% Return an object fold fun for building hashtrees, with an initialised
 %% accumulator
-foldobjects_buildtrees(IndexNs, LogLevels) ->
+foldobjects_buildtrees(IndexNs, LogLevels, KFF) ->
     InitMapFun =
         fun(IndexN) ->
             {IndexN, leveled_tictac:new_tree(IndexN, ?TREE_SIZE)}
@@ -1331,25 +1383,32 @@ foldobjects_buildtrees(IndexNs, LogLevels) ->
 
     FoldObjectsFun =
         fun(B, K, V, Acc) ->
-            {preflist, IndexN} = lists:keyfind(preflist, 1, V),
-            {hash, Hash} = lists:keyfind(hash, 1, V),
-            BinK = aae_util:make_binarykey(B, K),
-            BinExtractFun = fun(_BK, _V) -> {BinK, {is_hash, Hash}} end,
-            case lists:keyfind(IndexN, 1, Acc) of
-                {IndexN, Tree} ->
-                    Tree0 =
-                        leveled_tictac:add_kv(
-                            Tree,
-                            {null},
-                            {null},
-                            % BinExtractfun will ignore this dummy key and
-                            % value and substitute its own pre-defined values
-                            % to generate segment ID and hash
-                            BinExtractFun
-                        ),
-                    lists:keyreplace(IndexN, 1, Acc, {IndexN, Tree0});
+            case aae_util:apply_key_filter(KFF, {B, K}) of
+                true ->
+                    {preflist, IndexN} = lists:keyfind(preflist, 1, V),
+                    {hash, Hash} = lists:keyfind(hash, 1, V),
+                    BinK = aae_util:make_binarykey(B, K),
+                    BinExtractFun =
+                        fun(_BK, _V) -> {BinK, {is_hash, Hash}} end,
+                    case lists:keyfind(IndexN, 1, Acc) of
+                        {IndexN, Tree} ->
+                            Tree0 =
+                                leveled_tictac:add_kv(
+                                    Tree,
+                                    {null},
+                                    {null},
+                                    % BinExtractfun will ignore this dummy
+                                    % key and value and substitute its own
+                                    % pre-defined values to generate
+                                    % segment ID and hash
+                                    BinExtractFun
+                                ),
+                            lists:keyreplace(IndexN, 1, Acc, {IndexN, Tree0});
+                        false ->
+                            aae_util:log(aae14, [IndexN], LogLevels),
+                            Acc
+                    end;
                 false ->
-                    aae_util:log(aae14, [IndexN], LogLevels),
                     Acc
             end
         end,

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -98,7 +98,7 @@
     runner_queue = [] :: list(runner_work()),
     queue_backlog = false :: boolean(),
     block_next_put = false :: boolean(),
-    key_filter = none :: key_filter_fun()
+    key_filter = none :: key_include_fun()
 }).
 
 -record(options, {
@@ -110,7 +110,7 @@
     root_path :: list(),
     log_levels :: aae_util:log_levels(),
     leveled_options :: aae_keystore:leveled_options(),
-    key_filter = none :: key_filter_fun()
+    key_filter = none :: key_include_fun()
 }).
 
 -define(IS_DEF(Term), Term =/= undefined).
@@ -165,7 +165,7 @@
             binary()
         }
     ).
--type key_filter_fun() ::
+-type key_include_fun() ::
     none |
     fun(({aae_keystore:bucket(), aae_keystore:key()}|reset) -> boolean()).
 %% erlfmt:ignore-end
@@ -183,7 +183,7 @@
     version_vector/0,
     clock_hash/0,
     runner_work/0,
-    key_filter_fun/0
+    key_include_fun/0
 ]).
 
 %%%============================================================================
@@ -225,7 +225,7 @@ aae_start(
     fun((term()) -> tuple()),
     aae_util:log_levels() | undefined,
     aae_keystore:leveled_options(),
-    key_filter_fun()
+    key_include_fun()
 ) -> {ok, pid()}.
 %% @doc
 %% Start an AAE controller
@@ -736,7 +736,7 @@ handle_call(get_object_splitfun, _From, State = #state{object_splitfun = A}) ->
 handle_call({set_object_splitfun, A}, _From, State) ->
     {reply, ok, State#state{object_splitfun = A}};
 handle_call(reset_key_filter, _From, State) ->
-    {reply, aae_util:apply_key_filter(State#state.key_filter, reset), State};
+    {reply, aae_util:maybe_include_key(State#state.key_filter, reset), State};
 handle_call({prompt_nextrebuild, SecsFromNow}, _From, State) ->
     {Mega, Sec, Micros} = os:timestamp(),
     {reply, ok, State#state{next_rebuild = {Mega, Sec + SecsFromNow, Micros}}};
@@ -1033,7 +1033,7 @@ handle_call(
             {PL, T, SegMap} = lists:keyfind(PL, 1, SubTreeAcc),
             {SegID, HashAcc} = lists:keyfind(SegID, 1, SegMap),
             SubTreeAcc0 =
-                case aae_util:apply_key_filter(KFF, {B, K}) of
+                case aae_util:maybe_include_key(KFF, {B, K}) of
                     true ->
                         BinK = aae_util:make_binarykey(B, K),
                         {_, HashToAdd} =
@@ -1240,7 +1240,7 @@ handle_cast({put, IndexN, Bucket, Key, Clock, PrevClock, BinaryObj}, State) ->
         case
             {
                 lists:keyfind(IndexN, 1, TreeCaches),
-                aae_util:apply_key_filter(KFF, {Bucket, Key})
+                aae_util:maybe_include_key(KFF, {Bucket, Key})
             }
         of
             {false, _} ->
@@ -1368,13 +1368,13 @@ code_change(_OldVsn, State, _Extra) ->
 %%%============================================================================
 
 -spec foldobjects_buildtrees(
-    list(responsible_preflist()), aae_util:log_levels(), key_filter_fun()
+    list(responsible_preflist()), aae_util:log_levels(), key_include_fun()
 ) ->
     {aae_keystore:fold_fun(), list()}.
 %% @doc
 %% Return an object fold fun for building hashtrees, with an initialised
 %% accumulator
-foldobjects_buildtrees(IndexNs, LogLevels, KFF) ->
+foldobjects_buildtrees(IndexNs, LogLevels, KIF) ->
     InitMapFun =
         fun(IndexN) ->
             {IndexN, leveled_tictac:new_tree(IndexN, ?TREE_SIZE)}
@@ -1383,7 +1383,7 @@ foldobjects_buildtrees(IndexNs, LogLevels, KFF) ->
 
     FoldObjectsFun =
         fun(B, K, V, Acc) ->
-            case aae_util:apply_key_filter(KFF, {B, K}) of
+            case aae_util:maybe_include_key(KIF, {B, K}) of
                 true ->
                     {preflist, IndexN} = lists:keyfind(preflist, 1, V),
                     {hash, Hash} = lists:keyfind(hash, 1, V),

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -603,6 +603,15 @@ clock_compare(timeout, State = #state{repair_fun = RepairFun}) when
         [clock_compare, State#state.exchange_id],
         State#state.log_levels
     ),
+    BucketCountFun =
+        fun({B, _K, _C}, Acc) ->
+            maps:update_with(B, fun(V) -> V + 1 end, 1, Acc)
+        end,
+    BlueBuckets =
+        lists:foldl(BucketCountFun, maps:new(), State#state.blue_acc),
+    PinkBuckets =
+        lists:foldl(BucketCountFun, maps:new(), State#state.pink_acc),
+    aae_util:log(ex012, [BlueBuckets, PinkBuckets]),
     aae_util:log(
         ex008,
         [State#state.blue_acc, State#state.pink_acc],

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -195,7 +195,8 @@
     log_levels :: aae_util:log_levels(),
     scan_timeout = ?SCAN_TIMEOUT_MS :: non_neg_integer(),
     max_results = ?MAX_RESULTS :: pos_integer(),
-    purpose :: atom() | undefined
+    purpose :: atom() | undefined,
+    key_filter_fun = none :: aae_controller:key_filter_fun()
 }).
 
 -type branch_results() :: list({integer(), binary()}).
@@ -607,7 +608,21 @@ clock_compare(timeout, State = #state{repair_fun = RepairFun}) when
         [State#state.blue_acc, State#state.pink_acc],
         State#state.log_levels
     ),
-    RepairKeys = compare_clocks(State#state.blue_acc, State#state.pink_acc),
+    FilterFun =
+        fun({B, K, _VC}) ->
+            aae_util:apply_key_filter(State#state.key_filter_fun, {B, K})
+        end,
+    FilteredBlues = lists:filter(FilterFun, State#state.blue_acc),
+    FilteredPinks = lists:filter(FilterFun, State#state.pink_acc),
+    aae_util:log(
+        ex011,
+        [
+            length(State#state.blue_acc) - length(FilteredBlues),
+            length(State#state.pink_acc) - length(FilteredPinks)
+        ],
+        State#state.log_levels
+    ),
+    RepairKeys = compare_clocks(FilteredBlues, FilteredPinks),
     aae_util:log(
         ex004,
         [State#state.exchange_id, State#state.purpose, length(RepairKeys)],
@@ -879,7 +894,11 @@ process_options([{max_results, MaxResults} | Tail], State) when
 process_options([{purpose, Purpose} | Tail], State) when
     is_atom(Purpose)
 ->
-    process_options(Tail, State#state{purpose = Purpose}).
+    process_options(Tail, State#state{purpose = Purpose});
+process_options([{key_filter_fun, KFF} | Tail], State) when
+    is_function(KFF, 1)
+->
+    process_options(Tail, State#state{key_filter_fun = KFF}).
 
 -spec trigger_next(
     any(),

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -229,7 +229,8 @@
     | {scan_timeout, non_neg_integer()}
     | {log_levels, aae_util:log_levels()}
     | {max_results, non_neg_integer()}
-    | {purpose, atom()}.
+    | {purpose, atom()}
+    | {key_filter_fun, aae_controller:key_filter_fun()}.
 -type options() :: list(option_item()).
 -type send_message() ::
     fetch_root

--- a/src/aae_exchange.erl
+++ b/src/aae_exchange.erl
@@ -196,7 +196,7 @@
     scan_timeout = ?SCAN_TIMEOUT_MS :: non_neg_integer(),
     max_results = ?MAX_RESULTS :: pos_integer(),
     purpose :: atom() | undefined,
-    key_filter_fun = none :: aae_controller:key_filter_fun()
+    key_filter = none :: aae_controller:key_include_fun()
 }).
 
 -type branch_results() :: list({integer(), binary()}).
@@ -230,7 +230,7 @@
     | {log_levels, aae_util:log_levels()}
     | {max_results, non_neg_integer()}
     | {purpose, atom()}
-    | {key_filter_fun, aae_controller:key_filter_fun()}.
+    | {key_filter, aae_controller:key_include_fun()}.
 -type options() :: list(option_item()).
 -type send_message() ::
     fetch_root
@@ -620,7 +620,7 @@ clock_compare(timeout, State = #state{repair_fun = RepairFun}) when
     ),
     FilterFun =
         fun({B, K, _VC}) ->
-            aae_util:apply_key_filter(State#state.key_filter_fun, {B, K})
+            aae_util:maybe_include_key(State#state.key_filter, {B, K})
         end,
     FilteredBlues = lists:filter(FilterFun, State#state.blue_acc),
     FilteredPinks = lists:filter(FilterFun, State#state.pink_acc),
@@ -905,10 +905,10 @@ process_options([{purpose, Purpose} | Tail], State) when
     is_atom(Purpose)
 ->
     process_options(Tail, State#state{purpose = Purpose});
-process_options([{key_filter_fun, KFF} | Tail], State) when
-    is_function(KFF, 1)
+process_options([{key_filter, KIF} | Tail], State) when
+    is_function(KIF, 1)
 ->
-    process_options(Tail, State#state{key_filter_fun = KFF}).
+    process_options(Tail, State#state{key_filter = KIF}).
 
 -spec trigger_next(
     any(),

--- a/src/aae_util.erl
+++ b/src/aae_util.erl
@@ -16,7 +16,7 @@
     make_binarykey/2,
     safe_open/1,
     filter_log_levels/1,
-    apply_key_filter/2,
+    maybe_include_key/2,
     check_rootpath/1
 ]).
 
@@ -234,16 +234,16 @@ make_binarykey({Type, Bucket}, Key) when
 make_binarykey(Bucket, Key) when is_binary(Bucket), is_binary(Key) ->
     <<Bucket/binary, Key/binary>>.
 
--spec apply_key_filter(
-    aae_controller:key_filter_fun(),
+-spec maybe_include_key(
+    aae_controller:key_include_fun(),
     {aae_keystore:bucket(), aae_keystore:key()} | reset
 ) ->
     boolean().
-apply_key_filter(none, _Input) ->
+maybe_include_key(none, _Input) ->
     true;
-apply_key_filter(KeyFilterFun, {Bucket, Key}) ->
+maybe_include_key(KeyFilterFun, {Bucket, Key}) ->
     KeyFilterFun({Bucket, Key});
-apply_key_filter(KeyFilterFun, reset) ->
+maybe_include_key(KeyFilterFun, reset) ->
     KeyFilterFun(reset).
 
 %%%============================================================================

--- a/src/aae_util.erl
+++ b/src/aae_util.erl
@@ -97,7 +97,7 @@
                 >>
             },
         ex004 =>
-            {info, <<"Exchange id=~s purpose=~w led to prompting  of repair_count=~w">>},
+            {info, <<"Exchange id=~s purpose=~w led to prompting of repair_count=~w">>},
         ex005 =>
             {info, <<"Exchange id=~s throttled count=~w at state=~w">>},
         ex006 =>
@@ -116,7 +116,9 @@
         ex010 =>
             {warning, <<"Exchange not_supported in exchange id=~s for colour=~w purpose=~w">>},
         ex011 =>
-            {info, <<"Filtered clocks before comparison removing blue=~w pink =~w">>},
+            {info, <<"Filtered clocks before comparison removing blue=~w pink=~w">>},
+        ex012 =>
+            {info, <<"Bucket counts for blue ~0p pink ~0p">>},
         ks001 => 
             {info, <<"Key Store loading with id=~w has reached deferred count=~w">>},
         ks002 =>

--- a/src/aae_util.erl
+++ b/src/aae_util.erl
@@ -16,6 +16,7 @@
     make_binarykey/2,
     safe_open/1,
     filter_log_levels/1,
+    apply_key_filter/2,
     check_rootpath/1
 ]).
 
@@ -114,6 +115,8 @@
             },
         ex010 =>
             {warning, <<"Exchange not_supported in exchange id=~s for colour=~w purpose=~w">>},
+        ex011 =>
+            {info, <<"Filtered clocks before comparison removing blue=~w pink =~w">>},
         ks001 => 
             {info, <<"Key Store loading with id=~w has reached deferred count=~w">>},
         ks002 =>
@@ -228,6 +231,18 @@ make_binarykey({Type, Bucket}, Key) when
     <<Type/binary, Bucket/binary, Key/binary>>;
 make_binarykey(Bucket, Key) when is_binary(Bucket), is_binary(Key) ->
     <<Bucket/binary, Key/binary>>.
+
+-spec apply_key_filter(
+    aae_controller:key_filter_fun(),
+    {aae_keystore:bucket(), aae_keystore:key()} | reset
+) ->
+    boolean().
+apply_key_filter(none, _Input) ->
+    true;
+apply_key_filter(KeyFilterFun, {Bucket, Key}) ->
+    KeyFilterFun({Bucket, Key});
+apply_key_filter(KeyFilterFun, reset) ->
+    KeyFilterFun(reset).
 
 %%%============================================================================
 %%% Internal functions

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -324,6 +324,9 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
     ReturnFun = fun(R) -> RPid ! {result, R} end,
     RepairFun = fun(_KL) -> null end,
 
+    %% Add a key filter fun that never matches
+    KFF = fun({B, _K}) -> B =/= <<"SkipThisBucket">> end,
+
     {ok, Cntrl1} =
         aae_controller:aae_start(
             {parallel, StoreType},
@@ -332,7 +335,9 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
             [{2, 0}, {2, 1}],
             VnodePath1,
             SplitF,
-            [warn, error, critical]
+            [warn, error, critical],
+            [],
+            KFF
         ),
     {ok, Cntrl2} =
         aae_controller:aae_start(
@@ -342,7 +347,9 @@ dual_store_compare_tester(InitialKeyCount, StoreType) ->
             [{3, 0}, {3, 1}, {3, 2}],
             VnodePath2,
             SplitF,
-            [warn, error, critical]
+            [warn, error, critical],
+            [],
+            KFF
         ),
 
     initial_load(InitialKeyCount, Cntrl1, Cntrl2),

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -16,7 +16,7 @@
 ]).
 
 -export([
-    open/4,
+    open/5,
     put/4,
     read_repair/4,
     push/6,
@@ -27,6 +27,7 @@
     rebuild_complete/2,
     fold_aae/6,
     bucketlist_aae/1,
+    reset_keyfilter/1,
     close/1
 ]).
 
@@ -57,7 +58,8 @@
     aae :: parallel_so | parallel_ko | native,
     index_ns :: list(tuple()),
     root_path :: list(),
-    preflist_fun = null :: preflist_fun()
+    preflist_fun = null :: preflist_fun(),
+    key_filter = none :: aae_controller:key_filter_fun()
 }).
 
 -record(state, {
@@ -92,10 +94,16 @@
 %%% API
 %%%============================================================================
 
--spec open(list(), atom(), list(tuple()), preflist_fun() | null) -> {ok, pid()}.
+-spec open(
+    list(),
+    atom(),
+    list(tuple()),
+    preflist_fun() | null,
+    aae_controller:key_filter_fun()
+) -> {ok, pid()}.
 %% @doc
 %% Open a mock vnode
-open(Path, AAEType, IndexNs, PreflistFun) ->
+open(Path, AAEType, IndexNs, PreflistFun, KFF) ->
     gen_server:start(
         ?MODULE,
         [
@@ -103,7 +111,8 @@ open(Path, AAEType, IndexNs, PreflistFun) ->
                 aae = AAEType,
                 index_ns = IndexNs,
                 root_path = Path,
-                preflist_fun = PreflistFun
+                preflist_fun = PreflistFun,
+                key_filter = KFF
             }
         ],
         []
@@ -171,13 +180,18 @@ fold_aae(Vnode, Range, Segments, FoldObjectsFun, InitAcc, Elements) ->
         {fold_aae, Range, Segments, FoldObjectsFun, InitAcc, Elements}
     ).
 
--spec exchange_message(pid(), tuple() | atom(), list(tuple()), fun(
-    (any()) -> ok
-)) -> ok.
+-type return_fun() :: fun((any()) -> ok).
+
+-spec exchange_message(pid(), tuple() | atom(), list(tuple()), return_fun()) ->
+    ok.
 %% @doc
 %% Handle a message from an AAE exchange
 exchange_message(Vnode, Msg, IndexNs, ReturnFun) ->
     gen_server:call(Vnode, {aae, Msg, IndexNs, ReturnFun}).
+
+-spec reset_keyfilter(pid()) -> ok.
+reset_keyfilter(Pid) ->
+    gen_server:cast(Pid, reset_keyfilter).
 
 -spec bucketlist_aae(pid()) -> {async, fun(() -> list())}.
 %% @doc
@@ -261,7 +275,8 @@ init([Opts]) ->
             RP,
             fun from_aae_binary/1,
             undefined,
-            UpdBackendOpts
+            UpdBackendOpts,
+            Opts#options.key_filter
         ),
     erlang:send_after(?POKE_TIME, self(), poke),
     {ok, #state{
@@ -666,7 +681,10 @@ handle_cast({rebuild_complete, store}, State) ->
             {noreply, State}
     end;
 handle_cast({rebuild_complete, tree}, State) ->
-    {noreply, State#state{aae_rebuild = false}}.
+    {noreply, State#state{aae_rebuild = false}};
+handle_cast(reset_keyfilter, State) ->
+    ok = aae_controller:aae_reset_key_filter(State#state.aae_controller),
+    {noreply, State}.
 
 handle_info(poke, State) ->
     ok = aae_controller:aae_ping(

--- a/test/end_to_end/mock_kv_vnode.erl
+++ b/test/end_to_end/mock_kv_vnode.erl
@@ -59,7 +59,7 @@
     index_ns :: list(tuple()),
     root_path :: list(),
     preflist_fun = null :: preflist_fun(),
-    key_filter = none :: aae_controller:key_filter_fun()
+    key_filter = none :: aae_controller:key_include_fun()
 }).
 
 -record(state, {
@@ -99,7 +99,7 @@
     atom(),
     list(tuple()),
     preflist_fun() | null,
-    aae_controller:key_filter_fun()
+    aae_controller:key_include_fun()
 ) -> {ok, pid()}.
 %% @doc
 %% Open a mock vnode

--- a/test/end_to_end/mockvnode_SUITE.erl
+++ b/test/end_to_end/mockvnode_SUITE.erl
@@ -10,7 +10,10 @@
     loadexchangeandrebuild_stbucketko/1,
     loadexchangeandrebuild_tuplebucketko/1,
     loadexchangeandrebuild_stbucketso/1,
-    loadexchangeandrebuild_tuplebucketso/1
+    loadexchangeandrebuild_tuplebucketso/1,
+    keyfiltertest_tuplebucketko/1,
+    keyfiltertest_tuplebucketso/1,
+    keyfiltertest_stbucketko/1
 ]).
 
 all() ->
@@ -23,7 +26,10 @@ all() ->
         loadexchangeandrebuild_stbucketso,
         loadexchangeandrebuild_tuplebucketso,
         loadexchangeandrebuild_stbucketko,
-        loadexchangeandrebuild_tuplebucketko
+        loadexchangeandrebuild_tuplebucketko,
+        keyfiltertest_tuplebucketko,
+        keyfiltertest_tuplebucketso,
+        keyfiltertest_stbucketko
     ].
 
 -include("testutil.hrl").
@@ -81,13 +87,31 @@ mock_vnode_loadexchangeandrebuild_tester(TupleBuckets, PType) ->
             lists:nth(Idx + 1, IndexNs)
         end,
 
+    GetBucketFun =
+        fun(I) ->
+            case TupleBuckets of
+                true ->
+                    {?BUCKET_TYPE, integer_to_binary(I)};
+                false ->
+                    integer_to_binary(I)
+            end
+        end,
+    Bucket1 = GetBucketFun(1),
+    Bucket2 = GetBucketFun(2),
+    Bucket3 = GetBucketFun(3),
+    Bucket4 = GetBucketFun(4),
+
     % Start up to two mock vnodes
     % - VNN is a native vnode (where the AAE process will not keep a parallel
     % key store)
     % - VNP is a parallel vnode (where a separate AAE key store is required
     % to be kept in parallel)
-    {ok, VNN} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
-    {ok, VNP} = mock_kv_vnode:open(MockPathP, PType, IndexNs, PreflistFun),
+    {ok, VNN} = mock_kv_vnode:open(
+        MockPathN, native, IndexNs, PreflistFun, none
+    ),
+    {ok, VNP} = mock_kv_vnode:open(
+        MockPathP, PType, IndexNs, PreflistFun, none
+    ),
 
     RPid = self(),
     LogNotRepairFun =
@@ -122,19 +146,6 @@ mock_vnode_loadexchangeandrebuild_tester(TupleBuckets, PType) ->
     true = ExchangeState0 == root_compare,
 
     io:format("Same exchange - now using tree compare~n"),
-    GetBucketFun =
-        fun(I) ->
-            case TupleBuckets of
-                true ->
-                    {?BUCKET_TYPE, integer_to_binary(I)};
-                false ->
-                    integer_to_binary(I)
-            end
-        end,
-    Bucket1 = GetBucketFun(1),
-    Bucket2 = GetBucketFun(2),
-    Bucket3 = GetBucketFun(3),
-    Bucket4 = GetBucketFun(4),
 
     {ok, _TC_P0, TC_GUID0} =
         aae_exchange:start(
@@ -178,47 +189,8 @@ mock_vnode_loadexchangeandrebuild_tester(TupleBuckets, PType) ->
 
     RehashList = lists:sublist(ObjList, 700, 10),
 
-    PutFun =
-        fun(Store1, Store2) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                mock_kv_vnode:put(Store1, Object, PL, [Store2])
-            end
-        end,
-    DeleteFun =
-        fun(Stores) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                lists:foreach(
-                    fun(Store) ->
-                        mock_kv_vnode:backend_delete(
-                            Store,
-                            Object#r_object.bucket,
-                            Object#r_object.key,
-                            PL
-                        )
-                    end,
-                    Stores
-                )
-            end
-        end,
-    RehashFun =
-        fun(Stores) ->
-            fun(Object) ->
-                PL = PreflistFun(null, Object#r_object.key),
-                lists:foreach(
-                    fun(Store) ->
-                        mock_kv_vnode:rehash(
-                            Store,
-                            Object#r_object.bucket,
-                            Object#r_object.key,
-                            PL
-                        )
-                    end,
-                    Stores
-                )
-            end
-        end,
+    {PutFun, DeleteFun, RehashFun} =
+        testutil:get_modify_functions(PreflistFun),
 
     LogProgress("T1"),
     io:format("Load objects into both stores~n"),
@@ -415,8 +387,12 @@ mock_vnode_loadexchangeandrebuild_tester(TupleBuckets, PType) ->
     % Between startup and shutdown the next_rebuild will be rescheduled to
     % a different time, as the look at the last rebuild time and schedule
     % forward from there.
-    {ok, VNNa} = mock_kv_vnode:open(MockPathN, native, IndexNs, PreflistFun),
-    {ok, VNPa} = mock_kv_vnode:open(MockPathP, PType, IndexNs, PreflistFun),
+    {ok, VNNa} = mock_kv_vnode:open(
+        MockPathN, native, IndexNs, PreflistFun, none
+    ),
+    {ok, VNPa} = mock_kv_vnode:open(
+        MockPathP, PType, IndexNs, PreflistFun, none
+    ),
     {RebuildNa, false} = mock_kv_vnode:rebuild(VNNa, false),
     {RebuildPa, false} = mock_kv_vnode:rebuild(VNPa, false),
     io:format("Next rebuild vnn ~w vnp ~w~n", [RebuildNa, RebuildPa]),
@@ -1046,13 +1022,21 @@ mock_vnode_coveragefolder(Type, InitialKeyCount, TupleBuckets) ->
     % Open four vnodes to take two of the preflists each
     % - this is intended to replicate a ring-size=4, n-val=2 ring
     {ok, VNN1} =
-        mock_kv_vnode:open(MockPathN1, Type, [{1, 2}, {0, 2}], PreflistFun),
+        mock_kv_vnode:open(
+            MockPathN1, Type, [{1, 2}, {0, 2}], PreflistFun, none
+        ),
     {ok, VNN2} =
-        mock_kv_vnode:open(MockPathN2, Type, [{2, 2}, {1, 2}], PreflistFun),
+        mock_kv_vnode:open(
+            MockPathN2, Type, [{2, 2}, {1, 2}], PreflistFun, none
+        ),
     {ok, VNN3} =
-        mock_kv_vnode:open(MockPathN3, Type, [{3, 2}, {2, 2}], PreflistFun),
+        mock_kv_vnode:open(
+            MockPathN3, Type, [{3, 2}, {2, 2}], PreflistFun, none
+        ),
     {ok, VNN4} =
-        mock_kv_vnode:open(MockPathN4, Type, [{0, 2}, {3, 2}], PreflistFun),
+        mock_kv_vnode:open(
+            MockPathN4, Type, [{0, 2}, {3, 2}], PreflistFun, none
+        ),
 
     % Mapping of preflists to [Primary, Secondary] vnodes
     RingN =
@@ -1280,6 +1264,299 @@ mock_vnode_coveragefolder(Type, InitialKeyCount, TupleBuckets) ->
     ok = mock_kv_vnode:close(VNN2),
     ok = mock_kv_vnode:close(VNN3),
     ok = mock_kv_vnode:close(VNN4),
+    RootPath = testutil:reset_filestructure().
+
+keyfiltertest_tuplebucketso(_Config) ->
+    key_filter_tester(true, parallel_so).
+
+keyfiltertest_tuplebucketko(_Config) ->
+    key_filter_tester(true, parallel_ko).
+
+keyfiltertest_stbucketko(_Config) ->
+    key_filter_tester(false, parallel_ko).
+
+key_filter_tester(TupleBuckets, PType) ->
+    % Load up two vnodes with same data, with the data in each node split
+    % across 3 partitions (n=1).
+    %
+    % The purpose if to perform exchanges to first highlight no differences,
+    % and then once a difference is created, discover any difference
+    TestStartPoint = os:timestamp(),
+    LogProgress =
+        fun(Point) ->
+            io:format(
+                "Test reached point ~s in ~w s~n",
+                [
+                    Point,
+                    timer:now_diff(os:timestamp(), TestStartPoint) div
+                        1000
+                ]
+            )
+        end,
+
+    LogProgress("T0"),
+    InitialKeyCount = 60000,
+    RootPath = testutil:reset_filestructure(),
+    MockPathN = filename:join(RootPath, "mock_native/"),
+    MockPathP = filename:join(RootPath, "mock_parallel/"),
+
+    IndexNs = [{1, 3}, {2, 3}, {3, 3}],
+    PreflistFun =
+        fun(_B, K) ->
+            Idx = erlang:phash2(K) rem length(IndexNs),
+            lists:nth(Idx + 1, IndexNs)
+        end,
+
+    GetBucketFun =
+        fun(I) ->
+            case TupleBuckets of
+                true ->
+                    {?BUCKET_TYPE, integer_to_binary(I)};
+                false ->
+                    integer_to_binary(I)
+            end
+        end,
+    _Bucket1 = GetBucketFun(1),
+    _Bucket2 = GetBucketFun(2),
+    Bucket3 = GetBucketFun(3),
+    _Bucket4 = GetBucketFun(4),
+
+    %% Have a Key Filter fun which will check persistent_term for membership of
+    %% a list of buckets where the key should be excluded from the key cache
+    %% If the persistent term is updated, then reset call to the filter
+    %% function will lead to a new cache being formed,
+    KFF =
+        fun
+            ({Bucket, _Key}) ->
+                CacheMap =
+                    case get(aae_cache_filter_map) of
+                        FilterMap when is_map(FilterMap) ->
+                            FilterMap;
+                        _ ->
+                            maps:new()
+                    end,
+                case maps:get(Bucket, CacheMap, not_cached) of
+                    not_cached ->
+                        BucketList = persistent_term:get(
+                            aae_cache_filter_buckets, []
+                        ),
+                        ToInclude = not lists:member(Bucket, BucketList),
+                        put(
+                            aae_cache_filter_map,
+                            maps:put(Bucket, ToInclude, CacheMap)
+                        ),
+                        ToInclude;
+                    CachedResult ->
+                        CachedResult
+                end;
+            (reset) ->
+                erase(aae_cache_filter_map),
+                ok
+        end,
+
+    % Start with bucket 3 filtered
+    ok = persistent_term:put(aae_cache_filter_buckets, [Bucket3]),
+
+    % Start up to two mock vnodes
+    % - VNN is a native vnode (where the AAE process will not keep a parallel
+    % key store)
+    % - VNP is a parallel vnode (where a separate AAE key store is required
+    % to be kept in parallel)
+    {ok, VNN} = mock_kv_vnode:open(
+        MockPathN, native, IndexNs, PreflistFun, KFF
+    ),
+    {ok, VNP} = mock_kv_vnode:open(MockPathP, PType, IndexNs, PreflistFun, KFF),
+
+    RPid = self(),
+    LogNotRepairFun =
+        fun(KL) ->
+            lists:foreach(
+                fun({{B, K}, VCCompare}) ->
+                    io:format(
+                        "Delta found in ~w ~s ~w~n",
+                        [
+                            B,
+                            binary_to_list(K),
+                            VCCompare
+                        ]
+                    )
+                end,
+                KL
+            )
+        end,
+    _NullRepairFun = fun(_KL) -> ok end,
+    ReturnFun = fun(R) -> RPid ! {result, R} end,
+
+    io:format("Exchange between empty vnodes~n"),
+    {ok, _P0, GUID0} =
+        aae_exchange:start(
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun
+        ),
+    io:format("Exchange id ~s~n", [GUID0]),
+    {ExchangeState0, 0} = testutil:start_receiver(),
+    true = ExchangeState0 == root_compare,
+
+    io:format("Exchange between empty vnodes - with key_filter~n"),
+    {ok, _P1, GUID1} =
+        aae_exchange:start(
+            full,
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun,
+            none,
+            [{key_filter_fun, KFF}]
+        ),
+    io:format("Exchange id ~s~n", [GUID1]),
+    {ExchangeState1, 0} = testutil:start_receiver(),
+    true = ExchangeState1 == root_compare,
+
+    ok = mock_kv_vnode:exchange_message(VNN, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNS1 = testutil:start_receiver(),
+    ok = mock_kv_vnode:exchange_message(VNP, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNP1 = testutil:start_receiver(),
+
+    ObjList = testutil:gen_riakobjects(InitialKeyCount, [], TupleBuckets),
+    {NotToCache, ToCache} =
+        lists:partition(
+            fun(Obj) -> Obj#r_object.bucket == Bucket3 end,
+            ObjList
+        ),
+
+    {PutFun, _DeleteFun, _RehashFun} =
+        testutil:get_modify_functions(PreflistFun),
+
+    LogProgress("T1"),
+    io:format("Load objects into both stores~n"),
+    PutFun1 = PutFun(VNN, VNP),
+    PutFun2 = PutFun(VNP, VNN),
+    {OL1, OL2} = lists:split(length(ToCache) div 2, ToCache),
+    ok = lists:foreach(PutFun1, OL1),
+    ok = lists:foreach(PutFun2, OL2),
+
+    {ok, _P2, GUID2} =
+        aae_exchange:start(
+            full,
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun,
+            none,
+            [{key_filter_fun, KFF}]
+        ),
+    io:format("Exchange id ~s~n", [GUID2]),
+    {ExchangeState2, 0} = testutil:start_receiver(),
+    true = ExchangeState2 == root_compare,
+
+    ok = mock_kv_vnode:exchange_message(VNN, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNS2 = testutil:start_receiver(),
+    ok = mock_kv_vnode:exchange_message(VNP, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNP2 = testutil:start_receiver(),
+
+    false = CacheRootVNNS2 == CacheRootVNNS1,
+    false = CacheRootVNNP2 == CacheRootVNNP1,
+
+    LogProgress("T2"),
+    io:format("Load non-cached objects into different stores~n"),
+    PutFun1NC = PutFun(VNN, none),
+    PutFun2NC = PutFun(VNP, none),
+    {OLnc1, OLnc2} = lists:split(length(NotToCache) div 2, NotToCache),
+    ok = lists:foreach(PutFun1NC, OLnc1),
+    ok = lists:foreach(PutFun2NC, OLnc2),
+
+    {ok, _P3, GUID3} =
+        aae_exchange:start(
+            full,
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun,
+            none,
+            [{key_filter_fun, KFF}]
+        ),
+    io:format("Exchange id ~s~n", [GUID3]),
+    {ExchangeState3, 0} = testutil:start_receiver(),
+    true = ExchangeState3 == root_compare,
+
+    ok = mock_kv_vnode:exchange_message(VNN, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNS3 = testutil:start_receiver(),
+    ok = mock_kv_vnode:exchange_message(VNP, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNP3 = testutil:start_receiver(),
+
+    io:format(
+        "Confirm that loading into cache-bypass bucket leaves root unchanged~n"
+    ),
+    true = CacheRootVNNS3 == CacheRootVNNS2,
+    true = CacheRootVNNP3 == CacheRootVNNP2,
+
+    LogProgress("T3"),
+
+    io:format("Prompt for a rebuild of parallel~n"),
+    % The rebuild is a rebuild of both
+    % the store and the tree in the case of the parallel vnode, and just the
+    % tree in the case of the native rebuild
+    {RebuildVNPa, true} = mock_kv_vnode:rebuild(VNP, true),
+
+    true = RebuildVNPa > os:timestamp(),
+    % next rebuild was in the future, and is still scheduled as such
+    % key thing that the ongoing rebuild status is now true (the second
+    % element of the rebuild response)
+
+    io:format("Now poll to check to see when the rebuild is complete~n"),
+    wait_for_rebuild(VNP),
+
+    % Next rebuild times should now still be in the future
+    {RebuildVNPb, false} = mock_kv_vnode:rebuild(VNP, false),
+    true = RebuildVNPb > os:timestamp(),
+
+    ok = mock_kv_vnode:exchange_message(VNP, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNP4 = testutil:start_receiver(),
+    true = CacheRootVNNP3 == CacheRootVNNP4,
+
+    LogProgress("T4"),
+    io:format("Reset the bucket filter and rebuild again~n"),
+
+    ok = mock_kv_vnode:reset_keyfilter(VNP),
+    {_RebuildVNPc, true} = mock_kv_vnode:rebuild(VNP, true),
+    wait_for_rebuild(VNP),
+
+    ok = mock_kv_vnode:exchange_message(VNP, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNP5 = testutil:start_receiver(),
+    true = CacheRootVNNP5 == CacheRootVNNP4,
+
+    LogProgress("T5"),
+    io:format("Fetch clocks from the native node - confirm unchanged~n"),
+    ok = mock_kv_vnode:exchange_message(VNN, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNS4 = testutil:start_receiver(),
+    true = CacheRootVNNP5 == CacheRootVNNS4,
+    io:format("Starting point - native ok~n"),
+
+    ok = mock_kv_vnode:exchange_message(
+        VNN, {fetch_clocks, lists:seq(1, 10000)}, IndexNs, ReturnFun
+    ),
+    FetchClocksVNNA = testutil:start_receiver(),
+
+    ok = mock_kv_vnode:exchange_message(
+        VNN, {fetch_clocks, lists:seq(1, 10000)}, IndexNs, ReturnFun
+    ),
+    FetchClocksVNNB = testutil:start_receiver(),
+
+    true = FetchClocksVNNA == FetchClocksVNNB,
+    B3Clocks =
+        lists:filter(fun({B, _K, _C}) -> B == Bucket3 end, FetchClocksVNNB),
+    true = length(B3Clocks) > 0,
+
+    ok = mock_kv_vnode:exchange_message(VNN, fetch_root, IndexNs, ReturnFun),
+    CacheRootVNNS5 = testutil:start_receiver(),
+    true = CacheRootVNNP5 == CacheRootVNNS5,
+
+    LogProgress("T5"),
+    % Shutdown and clear down files
+    ok = mock_kv_vnode:close(VNN),
+    ok = mock_kv_vnode:close(VNP),
     RootPath = testutil:reset_filestructure().
 
 fold_metabin(<<>>, MDAcc) ->

--- a/test/end_to_end/mockvnode_SUITE.erl
+++ b/test/end_to_end/mockvnode_SUITE.erl
@@ -968,11 +968,7 @@ wait_for_rebuild(Vnode) ->
                         true;
                     false ->
                         timer:sleep(Wait),
-                        {_TSN, RSN} =
-                            mock_kv_vnode:rebuild(Vnode, false),
-                        % Waiting for rebuild status to be false
-                        % on both vnodes, which would indicate
-                        % that both rebuilds have completed
+                        {_TSN, RSN} = mock_kv_vnode:rebuild(Vnode, false),
                         (not RSN)
                 end
             end,
@@ -1316,10 +1312,8 @@ key_filter_tester(TupleBuckets, PType) ->
                     integer_to_binary(I)
             end
         end,
-    _Bucket1 = GetBucketFun(1),
-    _Bucket2 = GetBucketFun(2),
     Bucket3 = GetBucketFun(3),
-    _Bucket4 = GetBucketFun(4),
+    Bucket4 = GetBucketFun(4),
 
     %% Have a Key Filter fun which will check persistent_term for membership of
     %% a list of buckets where the key should be excluded from the key cache
@@ -1430,7 +1424,9 @@ key_filter_tester(TupleBuckets, PType) ->
         testutil:get_modify_functions(PreflistFun),
 
     LogProgress("T1"),
-    io:format("Load objects into both stores~n"),
+    io:format("Load ~w tree-cached objects into both stores~n", [
+        length(ToCache)
+    ]),
     PutFun1 = PutFun(VNN, VNP),
     PutFun2 = PutFun(VNP, VNN),
     {OL1, OL2} = lists:split(length(ToCache) div 2, ToCache),
@@ -1460,7 +1456,9 @@ key_filter_tester(TupleBuckets, PType) ->
     false = CacheRootVNNP2 == CacheRootVNNP1,
 
     LogProgress("T2"),
-    io:format("Load non-cached objects into different stores~n"),
+    io:format("Load ~w non-cached objects into different stores~n", [
+        length(NotToCache)
+    ]),
     PutFun1NC = PutFun(VNN, none),
     PutFun2NC = PutFun(VNP, none),
     {OLnc1, OLnc2} = lists:split(length(NotToCache) div 2, NotToCache),
@@ -1554,6 +1552,101 @@ key_filter_tester(TupleBuckets, PType) ->
     true = CacheRootVNNP5 == CacheRootVNNS5,
 
     LogProgress("T5"),
+    io:format("Rebuild tress on native~n"),
+    {_, true} = mock_kv_vnode:rebuild(VNN, true),
+    wait_for_rebuild(VNN),
+
+    {ok, _, GUID4} =
+        aae_exchange:start(
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun
+        ),
+    io:format("Exchange id ~s~n", [GUID4]),
+    {ExchangeState4, 0} = testutil:start_receiver(),
+    true = ExchangeState4 == root_compare,
+
+    % Now filter both bucket 3 and bucket 4
+    ok = persistent_term:put(aae_cache_filter_buckets, [Bucket3, Bucket4]),
+    ok = mock_kv_vnode:reset_keyfilter(VNN),
+    % Nothing initially changes - as caches built with old config
+
+    {ok, _, GUID5} =
+        aae_exchange:start(
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun
+        ),
+    io:format("Exchange id ~s~n", [GUID5]),
+    {ExchangeState5, 0} = testutil:start_receiver(),
+    true = ExchangeState5 == root_compare,
+
+    io:format("Rebuild tress on native - bucket 4 also ignored~n"),
+    {_, true} = mock_kv_vnode:rebuild(VNN, true),
+    wait_for_rebuild(VNN),
+
+    io:format(
+        "Exchange should mainly find bucket 4 - "
+        "but should overlap with some bucket 3 if we get enough results~n"
+    ),
+    {ok, _, GUID6} =
+        aae_exchange:start(
+            full,
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun,
+            none,
+            [{max_results, 2048}]
+        ),
+    io:format("Exchange id ~s~n", [GUID6]),
+    {ExchangeState6, N6} = testutil:start_receiver(),
+    true = ExchangeState6 == clock_compare,
+    true = N6 > 0,
+
+    io:format("Exchange filtering out B3 should find dummy delta~n"),
+    ok = persistent_term:put(aae_cache_filter_buckets, [Bucket3]),
+    {ok, _, GUID7} =
+        aae_exchange:start(
+            full,
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun,
+            none,
+            [{key_filter_fun, KFF}, {max_results, 2048}]
+        ),
+    io:format("Exchange id ~s~n", [GUID7]),
+    {ExchangeState7, N7} = testutil:start_receiver(),
+    true = ExchangeState7 == clock_compare,
+    true = N7 == 0,
+
+    io:format("Reset filter back to previous and rebuild~n"),
+    io:format(
+        "Have to rebuild parallel as well "
+        "as fetch_clocks will have `fixed` this side incorrectly too"
+    ),
+    ok = mock_kv_vnode:reset_keyfilter(VNN),
+    {_, true} = mock_kv_vnode:rebuild(VNN, true),
+    wait_for_rebuild(VNN),
+    ok = mock_kv_vnode:reset_keyfilter(VNP),
+    {_, true} = mock_kv_vnode:rebuild(VNP, true),
+    wait_for_rebuild(VNP),
+
+    {ok, _, GUID8} =
+        aae_exchange:start(
+            [{exchange_vnodesendfun(VNN), IndexNs}],
+            [{exchange_vnodesendfun(VNP), IndexNs}],
+            LogNotRepairFun,
+            ReturnFun
+        ),
+    io:format("Exchange id ~s~n", [GUID8]),
+    {ExchangeState8, 0} = testutil:start_receiver(),
+    true = ExchangeState8 == root_compare,
+
+    LogProgress("T6"),
     % Shutdown and clear down files
     ok = mock_kv_vnode:close(VNN),
     ok = mock_kv_vnode:close(VNP),

--- a/test/end_to_end/mockvnode_SUITE.erl
+++ b/test/end_to_end/mockvnode_SUITE.erl
@@ -1402,7 +1402,7 @@ key_filter_tester(TupleBuckets, PType) ->
             LogNotRepairFun,
             ReturnFun,
             none,
-            [{key_filter_fun, KFF}]
+            [{key_filter, KFF}]
         ),
     io:format("Exchange id ~s~n", [GUID1]),
     {ExchangeState1, 0} = testutil:start_receiver(),
@@ -1441,7 +1441,7 @@ key_filter_tester(TupleBuckets, PType) ->
             LogNotRepairFun,
             ReturnFun,
             none,
-            [{key_filter_fun, KFF}]
+            [{key_filter, KFF}]
         ),
     io:format("Exchange id ~s~n", [GUID2]),
     {ExchangeState2, 0} = testutil:start_receiver(),
@@ -1473,7 +1473,7 @@ key_filter_tester(TupleBuckets, PType) ->
             LogNotRepairFun,
             ReturnFun,
             none,
-            [{key_filter_fun, KFF}]
+            [{key_filter, KFF}]
         ),
     io:format("Exchange id ~s~n", [GUID3]),
     {ExchangeState3, 0} = testutil:start_receiver(),
@@ -1616,7 +1616,7 @@ key_filter_tester(TupleBuckets, PType) ->
             LogNotRepairFun,
             ReturnFun,
             none,
-            [{key_filter_fun, KFF}, {max_results, 2048}]
+            [{key_filter, KFF}, {max_results, 2048}]
         ),
     io:format("Exchange id ~s~n", [GUID7]),
     {ExchangeState7, N7} = testutil:start_receiver(),

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -6,7 +6,8 @@
     put_keys/3,
     put_keys/4,
     remove_keys/3,
-    gen_riakobjects/3
+    gen_riakobjects/3,
+    get_modify_functions/1
 ]).
 -export([calc_preflist/2]).
 -export([
@@ -191,6 +192,55 @@ gen_riakobjects(Count, ObjectList, TupleBuckets) ->
         contents = [#r_content{metadata = MD, value = Value}]
     },
     gen_riakobjects(Count - 1, [Obj | ObjectList], TupleBuckets).
+
+get_modify_functions(PreflistFun) ->
+    PutFun =
+        fun(Store1, Store2) ->
+            OtherStores =
+                case Store2 of
+                    none -> [];
+                    Store2 -> [Store2]
+                end,
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                mock_kv_vnode:put(Store1, Object, PL, OtherStores)
+            end
+        end,
+    DeleteFun =
+        fun(Stores) ->
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                lists:foreach(
+                    fun(Store) ->
+                        mock_kv_vnode:backend_delete(
+                            Store,
+                            Object#r_object.bucket,
+                            Object#r_object.key,
+                            PL
+                        )
+                    end,
+                    Stores
+                )
+            end
+        end,
+    RehashFun =
+        fun(Stores) ->
+            fun(Object) ->
+                PL = PreflistFun(null, Object#r_object.key),
+                lists:foreach(
+                    fun(Store) ->
+                        mock_kv_vnode:rehash(
+                            Store,
+                            Object#r_object.bucket,
+                            Object#r_object.key,
+                            PL
+                        )
+                    end,
+                    Stores
+                )
+            end
+        end,
+    {PutFun, DeleteFun, RehashFun}.
 
 add_randomincrement(Clock) ->
     RandIncr = rand:uniform(100),


### PR DESCRIPTION
Add support for using a filter function to determine if keys should be included in the tree cache, and in exchange results.

Intended to support the Riak `aae_tree_exclude` bucket property